### PR TITLE
WIP: Fix to tick scoring function

### DIFF
--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -114,7 +114,7 @@ function optimize_ticks_typed{T}(x_min::T, x_max::T, extend_ticks,
                     g = 0 < k < 2k_ideal ? 1 - abs(k - k_ideal) / k_ideal : 0.0
 
                     # coverage
-                    c = 1.5 * xspan/span
+                    c = 1.5*xspan/span
 
                     score = granularity_weight * g +
                             simplicity_weight * s +
@@ -124,6 +124,9 @@ function optimize_ticks_typed{T}(x_min::T, x_max::T, extend_ticks,
                     # strict limits on coverage
                     if strict_span && span > xspan
                         score -= 10000
+                        if span >= 4.0*xspan
+                            score -= 1000
+                        end
                     elseif !strict_span && (span >= 2.0*xspan || span < xspan)
                         score -= 1000
                     end

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -114,7 +114,7 @@ function optimize_ticks_typed{T}(x_min::T, x_max::T, extend_ticks,
                     g = 0 < k < 2k_ideal ? 1 - abs(k - k_ideal) / k_ideal : 0.0
 
                     # coverage
-                    c = 1.5*xspan/span
+                    c = 1.5 * xspan/span
 
                     score = granularity_weight * g +
                             simplicity_weight * s +


### PR DESCRIPTION
Fixes my bug where I was getting only a single tick on an axis for a specific data set, while (hopefully) making minimal changes. Comments welcome.

The test case resulting in a single tick is

```
scatter(s[:,1], s[:,2]) # ticks are fine
plot!(e1[:,1], e1[:,2]) # single y axis tick
```
where `s` and `e1` are defined [here](https://gist.github.com/crbinz/efdcfe4b99aa6430ebf021cf9240bde3)