### PR TITLE
RFC: favor tightest ticks

### DIFF
--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -169,8 +169,18 @@ function optimize_ticks_typed{T}(x_min::T, x_max::T, extend_ticks,
     end
 
     if isinf(high_score)
-        R = typeof(1.0 * one_t)
-        return R[x_min], x_min - one_t, x_min + one_t
+        if strict_span
+            warn("No strict ticks found")
+            return optimize_ticks_typed(x_min, x_max, extend_ticks,
+                                       Q, k_min,
+                                       k_max, k_ideal,
+                                       granularity_weight, simplicity_weight,
+                                       coverage_weight, niceness_weight,
+                                       false, span_buffer)
+        else
+            R = typeof(1.0 * one_t)
+            return R[x_min], x_min - one_t, x_min + one_t
+        end
     end
 
     return S_best, viewmin_best, viewmax_best

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -123,8 +123,9 @@ function optimize_ticks_typed{T}(x_min::T, x_max::T, extend_ticks,
 
                     # strict limits on coverage
                     if strict_span && span > xspan
-                        score -= 10000 * (span/xspan + 1)
-                    elseif !strict_span && (span >= 2.0*xspan || span < xspan)
+                        score -= 10000
+                    end
+                    if  span >= 2.0*xspan
                         score -= 1000
                     end
 

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -123,10 +123,7 @@ function optimize_ticks_typed{T}(x_min::T, x_max::T, extend_ticks,
 
                     # strict limits on coverage
                     if strict_span && span > xspan
-                        score -= 10000
-                        if span >= 4.0*xspan
-                            score -= 1000
-                        end
+                        score -= 10000 * (span/xspan + 1)
                     elseif !strict_span && (span >= 2.0*xspan || span < xspan)
                         score -= 1000
                     end


### PR DESCRIPTION
This PR makes sure that, should an exact solution with `strict_span = true` not exist, the tightest fit is selected.

3 Example plots:

```julia
scatter(rand(100), rand(100))
plot(sin, -pi, pi)
density(linspace(0.2291313228541989, 0.3318750511155737, 100))
```

Master:
![randold](https://user-images.githubusercontent.com/6333339/29743906-514e3db8-8a92-11e7-9419-b69e80f18f16.png)
![sineold](https://user-images.githubusercontent.com/6333339/29743908-5308e068-8a92-11e7-93d8-2293a642b7db.png)
![densityold](https://user-images.githubusercontent.com/6333339/29743909-54df175e-8a92-11e7-9dc6-a0dd6cc0778f.png)

PR:
![rand](https://user-images.githubusercontent.com/6333339/29743912-5a8ef89a-8a92-11e7-989e-2a6dfc92fd61.png)
![sine](https://user-images.githubusercontent.com/6333339/29743914-5cec2f90-8a92-11e7-8ff1-07a132153e49.png)
![density](https://user-images.githubusercontent.com/6333339/29743915-5ec45022-8a92-11e7-85da-78591134808c.png)

See Plots issue [#1045](https://github.com/JuliaPlots/Plots.jl/issues/1045)