### PR TITLE
import MersenneTwister

### DIFF
--- a/src/PlotUtils.jl
+++ b/src/PlotUtils.jl
@@ -8,6 +8,7 @@ using Reexport
 using Printf
 @reexport using Colors
 import Base: getindex
+import Random: MersenneTwister
 
 export
     ColorGradient,


### PR DESCRIPTION
`MersenneTwister` should be imported for Julia v1.0.
https://github.com/JuliaPlots/PlotUtils.jl/blob/4c8273f8129fd7af1c2e85f6eab629b544d9e559/src/adapted_grid.jl#L34