### PR TITLE
Make misc color library a global const to reduce package load time.

### DIFF
--- a/src/PlotUtils.jl
+++ b/src/PlotUtils.jl
@@ -38,7 +38,7 @@ export
 include("ticks.jl")
 
 function __init__()
-    register_color_library(:misc, _misc_color_lib)
+    register_color_library(:misc, _generate_misc_color_lib())
 end
 
 end # module

--- a/src/PlotUtils.jl
+++ b/src/PlotUtils.jl
@@ -38,7 +38,7 @@ export
 include("ticks.jl")
 
 function __init__()
-    register_color_library(:misc, _generate_misc_color_lib())
+    register_color_library(:misc, _misc_color_lib)
 end
 
 end # module

--- a/src/PlotUtils.jl
+++ b/src/PlotUtils.jl
@@ -37,4 +37,8 @@ export
 
 include("ticks.jl")
 
+function __init__()
+    register_color_library(:misc, _misc_color_lib)
+end
+
 end # module

--- a/src/color_gradients.jl
+++ b/src/color_gradients.jl
@@ -69,22 +69,20 @@ const _testColors = RGBA{Float64}[colorant"darkblue", colorant"blueviolet",  col
 
 const _gradients = [:Plots]
 
-function __init__()
-    misc = ColorLibrary(Dict(:default => :sequential, :sequential => :heat, :diverging => :bluesreds), Dict(
-        :reds         => [colorant"lightpink", colorant"darkred"],
-        :greens       => [colorant"lightgreen", colorant"darkgreen"],
-        :redsblues    => [colorant"darkred", RGB(0.8,0.85,0.8), colorant"darkblue"],
-        :bluesreds    => [colorant"darkblue", RGB(0.8,0.85,0.8), colorant"darkred"],
-        :heat         => [colorant"lightyellow", colorant"orange", colorant"darkred"],
-        :grays        => [RGB(.05,.05,.05),RGB(.95,.95,.95)],
-        :rainbow      => _rainbowColors,
-        :lightrainbow => map(lighten, _rainbowColors),
-        :darkrainbow  => map(darken, _rainbowColors),
-        :darktest     => _testColors,
-        :lighttest    => map(c -> lighten(c, 0.3), _testColors),
-    ))
-    register_color_library(:misc, misc)
-end
+_misc_color_lib = ColorLibrary(Dict(:default => :sequential, :sequential => :heat, :diverging => :bluesreds), Dict(
+    :reds         => [colorant"lightpink", colorant"darkred"],
+    :greens       => [colorant"lightgreen", colorant"darkgreen"],
+    :redsblues    => [colorant"darkred", RGB(0.8,0.85,0.8), colorant"darkblue"],
+    :bluesreds    => [colorant"darkblue", RGB(0.8,0.85,0.8), colorant"darkred"],
+    :heat         => [colorant"lightyellow", colorant"orange", colorant"darkred"],
+    :grays        => [RGB(.05,.05,.05),RGB(.95,.95,.95)],
+    :rainbow      => _rainbowColors,
+    :lightrainbow => map(lighten, _rainbowColors),
+    :darkrainbow  => map(darken, _rainbowColors),
+    :darktest     => _testColors,
+    :lighttest    => map(c -> lighten(c, 0.3), _testColors),
+))
+
 
 """
     clibraries()

--- a/src/color_gradients.jl
+++ b/src/color_gradients.jl
@@ -69,19 +69,36 @@ const _testColors = RGBA{Float64}[colorant"darkblue", colorant"blueviolet",  col
 
 const _gradients = [:Plots]
 
-_misc_color_lib = ColorLibrary(Dict(:default => :sequential, :sequential => :heat, :diverging => :bluesreds), Dict(
-    :reds         => [colorant"lightpink", colorant"darkred"],
-    :greens       => [colorant"lightgreen", colorant"darkgreen"],
-    :redsblues    => [colorant"darkred", RGB(0.8,0.85,0.8), colorant"darkblue"],
-    :bluesreds    => [colorant"darkblue", RGB(0.8,0.85,0.8), colorant"darkred"],
-    :heat         => [colorant"lightyellow", colorant"orange", colorant"darkred"],
-    :grays        => [RGB(.05,.05,.05),RGB(.95,.95,.95)],
+
+const _misc_color_lib_contents = Pair{Symbol,Vector{RGBA{Float64}}}[
+    :reds         => RGBA{Float64}[colorant"lightpink", colorant"darkred"],
+    :greens       => RGBA{Float64}[colorant"lightgreen", colorant"darkgreen"],
+    :redsblues    => RGBA{Float64}[colorant"darkred", RGB(0.8,0.85,0.8), colorant"darkblue"],
+    :bluesreds    => RGBA{Float64}[colorant"darkblue", RGB(0.8,0.85,0.8), colorant"darkred"],
+    :heat         => RGBA{Float64}[colorant"lightyellow", colorant"orange", colorant"darkred"],
+    :grays        => RGBA{Float64}[RGB(.05,.05,.05),RGB(.95,.95,.95)],
     :rainbow      => _rainbowColors,
     :lightrainbow => map(lighten, _rainbowColors),
     :darkrainbow  => map(darken, _rainbowColors),
     :darktest     => _testColors,
     :lighttest    => map(c -> lighten(c, 0.3), _testColors),
-))
+]
+
+function _generate_misc_color_lib()
+    lib = Dict{Symbol, Vector{RGBA{Float64}}}()
+    for elem in _misc_color_lib_contents
+        lib[elem[1]] = elem[2]
+    end
+
+    ColorLibrary(
+        Dict{Symbol, Symbol}(
+            :default => :sequential,
+            :sequential => :heat,
+            :diverging => :bluesreds
+        ),
+        lib
+    )
+end
 
 
 """

--- a/src/color_gradients.jl
+++ b/src/color_gradients.jl
@@ -69,8 +69,7 @@ const _testColors = RGBA{Float64}[colorant"darkblue", colorant"blueviolet",  col
 
 const _gradients = [:Plots]
 
-
-const _misc_color_lib_contents = Pair{Symbol,Vector{RGBA{Float64}}}[
+const _misc_color_lib = ColorLibrary(IdDict(:default => :sequential, :sequential => :heat, :diverging => :bluesreds), IdDict(
     :reds         => RGBA{Float64}[colorant"lightpink", colorant"darkred"],
     :greens       => RGBA{Float64}[colorant"lightgreen", colorant"darkgreen"],
     :redsblues    => RGBA{Float64}[colorant"darkred", RGB(0.8,0.85,0.8), colorant"darkblue"],
@@ -82,23 +81,7 @@ const _misc_color_lib_contents = Pair{Symbol,Vector{RGBA{Float64}}}[
     :darkrainbow  => map(darken, _rainbowColors),
     :darktest     => _testColors,
     :lighttest    => map(c -> lighten(c, 0.3), _testColors),
-]
-
-function _generate_misc_color_lib()
-    lib = Dict{Symbol, Vector{RGBA{Float64}}}()
-    for elem in _misc_color_lib_contents
-        lib[elem[1]] = elem[2]
-    end
-
-    ColorLibrary(
-        Dict{Symbol, Symbol}(
-            :default => :sequential,
-            :sequential => :heat,
-            :diverging => :bluesreds
-        ),
-        lib
-    )
-end
+))
 
 
 """


### PR DESCRIPTION
Reduces load time of PlotUtils by 45% and total load time of Plots by 20%.

@SimonDanisch, you touched `__init__` last, is this Ok?

Closes #51.