### PR TITLE
Fix exponential color scale

### DIFF
--- a/src/color_gradients.jl
+++ b/src/color_gradients.jl
@@ -219,7 +219,7 @@ function cgrad(arg; alpha = nothing, scale = :identity)
     elseif scale == :ln
         log.(range(1; stop=pi, length=length(colors)))
     elseif scale in (:exp, :exp10)
-        (exp10.(range(0; stop=1, length=length(colors))) - 1) / 9
+        (exp10.(range(0; stop=1, length=length(colors))) .- 1) ./ 9
     elseif isa(arg, ColorGradient)
         arg.values
     else


### PR DESCRIPTION
This PR enables the use of an exponential color scale. Currently running
```julia
using Plots
plotlyjs()
heatmap(rand(10, 10), color = cgrad(:viridis, scale = :exp))
```
yields the following error message:
```julia
ERROR: MethodError: no method matching -(::Array{Float64,1}, ::Int64)
Closest candidates are:
  -(::Complex{Bool}, ::Real) at complex.jl:298
  -(::Missing, ::Number) at missing.jl:93
  -(::Base.CoreLogging.LogLevel, ::Integer) at logging.jl:107
  ...
Stacktrace:
 [1] #cgrad#21(::Nothing, ::Symbol, ::Function, ::Symbol) at /home/david/.julia/dev/PlotUtils/src/color_gradients.jl:222
 [2] (::getfield(PlotUtils, Symbol("#kw##cgrad")))(::NamedTuple{(:scale,),Tuple{Symbol}}, ::typeof(cgrad), ::Symbol) at ./none:0
 [3] top-level scope at none:0
```