### PR TITLE
don't save alpha state for gradients

### DIFF
--- a/src/color_gradients.jl
+++ b/src/color_gradients.jl
@@ -177,13 +177,7 @@ function _color_list(arg, ::Nothing)
     cgrad_colors(arg)
 end
 
-function _color_list(arg, alpha)
-    colors = cgrad_colors(arg)
-    for i in eachindex(colors)
-        colors[i] = RGBA{Float64}(convert(RGB{Float64}, colors[i]), alpha)
-    end
-    colors
-end
+_color_list(arg, alpha) = RGBA{Float64}.(convert.(RGB{Float64}, cgrad_colors(arg)), alpha)
 
 cgrad(arg::Symbol, cl::Symbol, values; kw...) = cgrad(cgrad_colors(arg, color_library = cl), values; kw...)
 


### PR DESCRIPTION
Currently the alpha state for color gradients is saved in PlotUtils:
```julia
# not specifying alpha and setting alpha = nothing result in alpha = 1.0 here:
julia> cgrad(:blues)
ColorGradient(RGBA{Float64}[RGBA{Float64}(0.678431,0.847059,0.901961,1.0), RGBA{Float64}(0.0,0.0,0.545098,1.0)], [0.0, 1.0])

julia> cgrad(:blues, alpha = nothing)
ColorGradient(RGBA{Float64}[RGBA{Float64}(0.678431,0.847059,0.901961,1.0), RGBA{Float64}(0.0,0.0,0.545098,1.0)], [0.0, 1.0])

# let's call cgrad with a different alpha value
julia> cgrad(:blues, alpha = 0.5)
ColorGradient(RGBA{Float64}[RGBA{Float64}(0.678431,0.847059,0.901961,0.5), RGBA{Float64}(0.0,0.0,0.545098,0.5)], [0.0, 1.0])

# now the same commands as above return a gradient with alpha = 0.5
julia> cgrad(:blues) # alpha = 0.5
ColorGradient(RGBA{Float64}[RGBA{Float64}(0.678431,0.847059,0.901961,0.5), RGBA{Float64}(0.0,0.0,0.545098,0.5)], [0.0, 1.0])

julia> cgrad(:blues, alpha = nothing) # alpha = 0.5
ColorGradient(RGBA{Float64}[RGBA{Float64}(0.678431,0.847059,0.901961,0.5), RGBA{Float64}(0.0,0.0,0.545098,0.5)], [0.0, 1.0])
```

I'm not a 100% sure if this is intended, but I suppose it is not. Do you happen to know more about this @mkborregaard ?

---
With this PR this secret alpha state is removed:
```julia
julia> cgrad(:blues, alpha = 0.5)
ColorGradient(RGBA{Float64}[RGBA{Float64}(0.678431,0.847059,0.901961,0.5), RGBA{Float64}(0.0,0.0,0.545098,0.5)], [0.0, 1.0])

julia> cgrad(:blues)
ColorGradient(RGBA{Float64}[RGBA{Float64}(0.678431,0.847059,0.901961,1.0), RGBA{Float64}(0.0,0.0,0.545098,1.0)], [0.0, 1.0])

julia> cgrad(:blues, alpha = nothing)
ColorGradient(RGBA{Float64}[RGBA{Float64}(0.678431,0.847059,0.901961,1.0), RGBA{Float64}(0.0,0.0,0.545098,1.0)], [0.0, 1.0])
```

This is also in line with the behaviour of `plot_color`:
```julia
julia> plot_color(:red, 0.5)
RGBA{Float64}(1.0,0.0,0.0,0.5)

julia> plot_color(:red)
RGBA{Float64}(1.0,0.0,0.0,1.0)

julia> plot_color(:red, nothing)
RGBA{Float64}(1.0,0.0,0.0,1.0)
```