### PR TITLE
Fix infinite loop in tick calculation

### DIFF
--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -101,7 +101,7 @@ function optimize_ticks_typed(x_min::T, x_max::T, extend_ticks,
                 if stp < eps()
                     continue
                 end
-                r = ceil(Int, (x_max - span) / (stp * one_t))
+                r = ceil(Int64, (x_max - span) / (stp * one_t))
 
                 while r*stp * one_t <= x_min
                     # Filter or expand ticks

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -101,7 +101,7 @@ function optimize_ticks_typed(x_min::T, x_max::T, extend_ticks,
                 if stp < eps()
                     continue
                 end
-                r = ceil((x_max - span) / (stp * one_t))
+                r = ceil(Int, (x_max - span) / (stp * one_t))
 
                 while r*stp * one_t <= x_min
                     # Filter or expand ticks
@@ -121,13 +121,8 @@ function optimize_ticks_typed(x_min::T, x_max::T, extend_ticks,
                     if strict_span
                         viewmin = max(viewmin, x_min)
                         viewmax = min(viewmax, x_max)
-                        if span_buffer == nothing
-                            S = filter(si -> viewmin <= si <= viewmax, S)
-                        else
-                            buf = span_buffer * (viewmax - viewmin)
-                            # @show buf
-                            S = filter(si -> viewmin-buf <= si <= viewmax+buf, S)
-                        end
+                        buf = something(span_buffer, 0) * (viewmax - viewmin)
+                        S = filter(si -> viewmin-buf <= si <= viewmax+buf, S)
                     end
 
                     # evaluate quality of ticks

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,4 +78,14 @@ end
 
 @testset "ticks" begin
     @test optimize_ticks(-1,2) == ([-1.0,0.0,1.0,2.0],-1.0,2.0)
+    
+    @testset "small range $x, $(i)ϵ" for x in exp10.(-12:12), i in -5:5
+        y = x + i*eps(x)
+        x,y = minmax(x,y)
+        ticks = PlotUtils.optimize_ticks(x, y)[1]
+        @test issorted(ticks)
+        @test all(x .<= ticks .<= y)
+        # Fails:
+        # @test allunique(ticks)
+    end
 end


### PR DESCRIPTION
Fixes JuliaPlots/Plots.jl#2039, which happens when the float-point `r` during tick calculation is large enough that `r == r+1`.  The results of tick calculations are still not great in the tested cases, and it doesn't actually plot, but at least it doesn't hang. 
A better solution is probably to do tick computations with a decimal type, which should fix the formatting problems as well. But currently `Showoff` doesn't work well with `Decimals`.

The code looks like it's trying to be careful about types (using `one_t = convert(T, one(T))`), but I'm not sure which types other than plain floating point actually work, so maybe I broke something. Any ideas?