### PR TITLE
add getindex method for ColorGradient and Arrays of indices

### DIFF
--- a/src/color_gradients.jl
+++ b/src/color_gradients.jl
@@ -119,6 +119,8 @@ function Base.getindex(gradient::ColorGradient, z::Number)
     cs[end]
 end
 
+Base.getindex(gradient::ColorGradient, inds::AbstractArray) = map(i -> getindex(gradient, i), inds)
+
 
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
Could be nice to have 
```julia
grad[0:0.2:1]
```
as a shorter alternative for
```julia
[grad[z] for z in 0:0.2:1]
```