### PR TITLE
Ticks significant digits fix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,4 +19,4 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Plots"]
+test = ["Test", "Statistics"]

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Colors = "0"
 Reexport = "0"
 
 [extras]
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,2 +1,3 @@
 [deps]
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,2 @@
 [deps]
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,6 +90,7 @@ end
         # @test allunique(ticks)
     end
 
+    @testset "digits $((10^n)-1)*10^$i" for n in 1:9, i in -9:9
         y0 = 10^n
         x0 = y0-1
         x, y = (x0,y0) .* 10.0^i

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using PlotUtils
-using Plots: is_uniformly_spaced
 using Test
+using Statistics: mean
 
 # TODO: real tests
 
@@ -76,6 +76,13 @@ end
 
 # ----------------------
 # ticks
+
+# Copied from Plots.is_uniformly_spaced to avoid dependency on recent version
+# on Plots which is not used on Travis.
+function is_uniformly_spaced(v; tol=1e-6)
+  dv = diff(v)
+  maximum(dv) - minimum(dv) < tol * mean(abs.(dv))
+end
 
 @testset "ticks" begin
     @test optimize_ticks(-1,2) == ([-1.0,0.0,1.0,2.0],-1.0,2.0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using PlotUtils
+using Plots: is_uniformly_spaced
 using Test
 
 # TODO: real tests
@@ -87,5 +88,15 @@ end
         @test all(x .<= ticks .<= y)
         # Fails:
         # @test allunique(ticks)
+    end
+
+        y0 = 10^n
+        x0 = y0-1
+        x, y = (x0,y0) .* 10.0^i
+        ticks = optimize_ticks(x, y)[1]
+        @test length(ticks) >= 2
+        @test issorted(ticks)
+        @test all(x .<= ticks .<= y)
+        @test is_uniformly_spaced(ticks)
     end
 end


### PR DESCRIPTION
This fixes the choice of ticks for x range with 4 or more digits, e.g. (1234,1235), which used to produce a single tick. Being as conservative as possible with the number of significant digits, to avoid floating-point problems where possible.