### PR TITLE
support equal extrema in adapted_grid

### DIFF
--- a/src/adapted_grid.jl
+++ b/src/adapted_grid.jl
@@ -12,8 +12,11 @@ The parameter `max_recusions` computes how many times each interval is allowed t
 be refined.
 """
 function adapted_grid(f, minmax::Tuple{Real, Real}; max_recursions = 7)
-    if minmax[1] >= minmax[2]
+    if minmax[1] > minmax[2]
         throw(ArgumentError("interval must be given as (min, max)"))
+    elseif minmax[1] == minmax[2]
+        x = minmax[1]
+        return [x], [f(x)]
     end
 
     # When an interval has curvature smaller than this, stop refining it.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -114,3 +114,30 @@ end
         @test is_uniformly_spaced(ticks)
     end
 end
+
+# ----------------------
+# adapted grid
+
+@testset "adapted grid" begin
+    f = sin
+    int = (0, π)
+    xs, fs = adapted_grid(f, int)
+    l = length(xs) - 1
+    for i in 1:l
+        for λ in 0:0.1:1
+            # test that `f` is well approximated by a line
+            # in the interval `(xs[i], xs[i+1])`
+            x = λ * xs[i] + (1 - λ) * xs[i+1]
+            y = λ * fs[i] + (1 - λ) * fs[i+1]
+            @test y ≈ f(x) atol = 1e-2
+        end
+    end
+
+    int = (2, 2)
+    xs, fs = adapted_grid(f, int)
+    @test xs == [2]
+    @test fs == [f(2)]
+
+    int = (2, 1)
+    @test_throws ArgumentError adapted_grid(f, int)
+end


### PR DESCRIPTION
This comes up using "split-apply-combine" on a dataset, when one gets some column that for some group only has a unique value, so the extrema are equal. I felt that there was no harm in supporting that here.