### PR TITLE
make optimize_ticks faster

### DIFF
--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -164,7 +164,7 @@ function optimize_ticks_typed(x_min::T, x_max::T, extend_ticks,
     sigdigits_z = max(1, x_digits - z + q_extra_digits)
 
     high_score = -Inf
-    S_best = Array{typeof(1.0 * one_t)}(undef, )
+    S_best = Array{typeof(1.0 * one_t)}(undef, 1)
     viewmin_best, viewmax_best = x_min, x_max
 
     while 2k_max * 10.0^(z+1) * one_t > xspan

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -201,7 +201,7 @@ function optimize_ticks_typed(x_min::T, x_max::T, extend_ticks,
                         viewmin = max(viewmin, x_min)
                         viewmax = min(viewmax, x_max)
                         buf = something(span_buffer, 0) * (viewmax - viewmin)
-                        S = filter(si -> viewmin-buf <= si <= viewmax+buf, S)
+                        S = S[(viewmin-buf) .<= S .<= (viewmax + buf)]
                     end
 
                     # evaluate quality of ticks

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -161,7 +161,7 @@ function optimize_ticks_typed(x_min::T, x_max::T, extend_ticks,
     # for q values specified in Q
     x_digits = bounding_order_of_magnitude(max(abs(x_min), abs(x_max)))
     q_extra_digits = maximum(postdecimal_digits(q[1]) for q in Q)
-    sigdigits(z) = max(1, x_digits - z + q_extra_digits)
+    sigdigits_z = max(1, x_digits - z + q_extra_digits)
 
     high_score = -Inf
     S_best = Array{typeof(1.0 * one_t)}(undef, )

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -167,6 +167,10 @@ function optimize_ticks_typed(x_min::T, x_max::T, extend_ticks,
     S_best = Array{typeof(1.0 * one_t)}(undef, 1)
     viewmin_best, viewmax_best = x_min, x_max
 
+
+    sig_tens = 10 ^ sigdigits_z
+    round_sigdigits(x) = round(x * sig_tens) / sig_tens
+
     while 2k_max * 10.0^(z+1) * one_t > xspan
         for k in k_min:2k_max
             for (q, qscore) in Q

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -171,8 +171,15 @@ function optimize_ticks_typed(x_min::T, x_max::T, extend_ticks,
     sig_tens = 10 ^ sigdigits_z
     round_sigdigits(x) = round(x * sig_tens) / sig_tens
 
+
+    prealloc_Ss = if extend_ticks
+        [Array{typeof(1.0 * one_t)}(undef, Int(3 * k)) for k in k_min:2k_max]
+    else
+        [Array{typeof(1.0 * one_t)}(undef, k) for k in k_min:2k_max]
+    end
+
     while 2k_max * 10.0^(z+1) * one_t > xspan
-        for k in k_min:2k_max
+        for (ik, k) in enumerate(k_min:2k_max)
             for (q, qscore) in Q
                 tickspan = q * 10.0^z * one_t
                 span = (k - 1) * tickspan
@@ -189,13 +196,13 @@ function optimize_ticks_typed(x_min::T, x_max::T, extend_ticks,
                 while r*stp * one_t <= x_min
                     # Filter or expand ticks
                     if extend_ticks
-                        S = Array{typeof(1.0 * one_t)}(undef, Int(3 * k))
+                        S = prealloc_Ss[ik]
                         for i in 0:(3*k - 1)
                             S[i+1] = round_sigdigits((r + i - k) * tickspan)
                         end
                         viewmin, viewmax = S[k + 1], S[2 * k]
                     else
-                        S = Array{typeof(1.0 * one_t)}(undef, k)
+                        S = prealloc_Ss[ik]
                         for i in 0:(k - 1)
                             S[i+1] = round_sigdigits((r + i) * tickspan)
                         end

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -187,13 +187,13 @@ function optimize_ticks_typed(x_min::T, x_max::T, extend_ticks,
                     if extend_ticks
                         S = Array{typeof(1.0 * one_t)}(undef, Int(3 * k))
                         for i in 0:(3*k - 1)
-                            S[i+1] = round((r + i - k) * tickspan, sigdigits=sigdigits(z))
+                            S[i+1] = round_sigdigits((r + i - k) * tickspan)
                         end
                         viewmin, viewmax = S[k + 1], S[2 * k]
                     else
                         S = Array{typeof(1.0 * one_t)}(undef, k)
                         for i in 0:(k - 1)
-                            S[i+1] = round((r + i) * tickspan, sigdigits=sigdigits(z))
+                            S[i+1] = round_sigdigits((r + i) * tickspan)
                         end
                         viewmin, viewmax = S[1], S[end]
                     end

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -168,6 +168,9 @@ function optimize_ticks_typed(x_min::T, x_max::T, extend_ticks,
     viewmin_best, viewmax_best = x_min, x_max
 
 
+    # we preallocate arrays that hold all required S arrays for every given
+    # the k parameter, so we don't have to create them again and again, which
+    # saves many allocations
     prealloc_Ss = if extend_ticks
         [Array{typeof(1.0 * one_t)}(undef, Int(3 * k)) for k in k_min:2k_max]
     else

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -168,10 +168,6 @@ function optimize_ticks_typed(x_min::T, x_max::T, extend_ticks,
     viewmin_best, viewmax_best = x_min, x_max
 
 
-    sig_tens = 10 ^ sigdigits_z
-    round_sigdigits(x) = round(x * sig_tens) / sig_tens
-
-
     prealloc_Ss = if extend_ticks
         [Array{typeof(1.0 * one_t)}(undef, Int(3 * k)) for k in k_min:2k_max]
     else
@@ -198,14 +194,22 @@ function optimize_ticks_typed(x_min::T, x_max::T, extend_ticks,
                     if extend_ticks
                         S = prealloc_Ss[ik]
                         for i in 0:(3*k - 1)
-                            S[i+1] = round_sigdigits((r + i - k) * tickspan)
+                            S[i+1] = (r + i - k) * tickspan
                         end
+                        # round only those values that end up as viewmin and viewmax
+                        # to save computation time
+                        S[k + 1] = round(S[k + 1], sigdigits = sigdigits_z)
+                        S[2 * k] = round(S[2 * k], sigdigits = sigdigits_z)
                         viewmin, viewmax = S[k + 1], S[2 * k]
                     else
                         S = prealloc_Ss[ik]
                         for i in 0:(k - 1)
-                            S[i+1] = round_sigdigits((r + i) * tickspan)
+                            S[i+1] = (r + i) * tickspan
                         end
+                        # round only those values that end up as viewmin and viewmax
+                        # to save computation time
+                        S[1] = round(S[1], sigdigits = sigdigits_z)
+                        S[end] = round(S[end], sigdigits = sigdigits_z)
                         viewmin, viewmax = S[1], S[end]
                     end
                     if strict_span


### PR DESCRIPTION
This still fails a couple of tests, although I'm not sure why 1000 or so tests don't fail and a random looking subset does. Anyway, the changes here make the function about 12 times faster for me, from about 4.2ms to 395µs. Maybe someone else has an idea how to fix the tests.