### PR TITLE
Fix rounding in optimize_ticks

### DIFF
--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -161,7 +161,7 @@ function optimize_ticks_typed(x_min::T, x_max::T, extend_ticks,
     # for q values specified in Q
     x_digits = bounding_order_of_magnitude(max(abs(x_min), abs(x_max)))
     q_extra_digits = maximum(postdecimal_digits(q[1]) for q in Q)
-    sigdigits_z = max(1, x_digits - z + q_extra_digits)
+    sigdigits(z) = max(1, x_digits - z + q_extra_digits)
 
     high_score = -Inf
     S_best = Array{typeof(1.0 * one_t)}(undef, 1)
@@ -201,8 +201,8 @@ function optimize_ticks_typed(x_min::T, x_max::T, extend_ticks,
                         end
                         # round only those values that end up as viewmin and viewmax
                         # to save computation time
-                        S[k + 1] = round(S[k + 1], sigdigits = sigdigits_z)
-                        S[2 * k] = round(S[2 * k], sigdigits = sigdigits_z)
+                        S[k + 1] = round(S[k + 1], sigdigits = sigdigits(z))
+                        S[2 * k] = round(S[2 * k], sigdigits = sigdigits(z))
                         viewmin, viewmax = S[k + 1], S[2 * k]
                     else
                         S = prealloc_Ss[ik]
@@ -211,8 +211,8 @@ function optimize_ticks_typed(x_min::T, x_max::T, extend_ticks,
                         end
                         # round only those values that end up as viewmin and viewmax
                         # to save computation time
-                        S[1] = round(S[1], sigdigits = sigdigits_z)
-                        S[k] = round(S[k], sigdigits = sigdigits_z)
+                        S[1] = round(S[1], sigdigits = sigdigits(z))
+                        S[k] = round(S[k], sigdigits = sigdigits(z))
                         viewmin, viewmax = S[1], S[k]
                     end
                     if strict_span

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -123,10 +123,14 @@ end
 
     @testset "random ranges" begin
         r = [minmax(rand(-100:100,2)...) .* 10.0^i for _=1:10, i=-5:5]
-        @testset "random ranges $r" for r in r
-            (x,y) = r
+        @testset "random range $x..$y" for (x,y) in r
             test_ticks(x, y, optimize_ticks(x, y)[1])
         end
+    end
+
+    # issue 86
+    let x = -1.0, y = 13.0
+        test_ticks(x, y, optimize_ticks(x, y, k_min = 4, k_max = 8)[1])
     end
 
     @testset "digits" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -93,25 +93,50 @@ end
         ["2001-01-01", "2026-01-01", "2051-01-01", "2076-01-01"]
     )
 
-    @testset "small range $x, $(i)ϵ" for x in exp10.(-12:12), i in -5:5
-        y = x + i*eps(x)
-        x,y = minmax(x,y)
-        ticks = PlotUtils.optimize_ticks(x, y)[1]
-        @test issorted(ticks)
-        @test all(x .<= ticks .<= y)
-        # Fails:
-        # @test allunique(ticks)
+    @testset "small range" begin
+        @testset "small range $x, $(i)ϵ" for x in exp10.(-12:12), i in -5:5
+            y = x + i*eps(x)
+            x,y = minmax(x,y)
+            ticks = PlotUtils.optimize_ticks(x, y)[1]
+            @test issorted(ticks)
+            @test all(x .<= ticks .<= y)
+            # Fails:
+            # @test allunique(ticks)
+        end
     end
 
-    @testset "digits $((10^n)-1)*10^$i" for n in 1:9, i in -9:9
-        y0 = 10^n
-        x0 = y0-1
-        x, y = (x0,y0) .* 10.0^i
-        ticks = optimize_ticks(x, y)[1]
-        @test length(ticks) >= 2
+    function test_ticks(x, y, ticks)
         @test issorted(ticks)
         @test all(x .<= ticks .<= y)
-        @test is_uniformly_spaced(ticks)
+        if x < y
+            @test length(ticks) >= 2
+            @test is_uniformly_spaced(ticks)
+        end
+    end
+
+    @testset "fixed ranges" begin
+        @testset "fixed range $x..$y" for (x,y) in [(2,14),(14,25),(16,36),(57,69)]
+            test_ticks(x, y, optimize_ticks(x, y)[1])
+            test_ticks(-y, -x, optimize_ticks(-y, -x)[1])
+        end
+    end
+
+    @testset "random ranges" begin
+        r = [minmax(rand(-100:100,2)...) .* 10.0^i for _=1:10, i=-5:5]
+        @testset "random ranges $r" for r in r
+            (x,y) = r
+            test_ticks(x, y, optimize_ticks(x, y)[1])
+        end
+    end
+
+    @testset "digits" begin
+        @testset "digits $((10^n)-1)*10^$i" for n in 1:9, i in -9:9
+            y0 = 10^n
+            x0 = y0-1
+            x, y = (x0,y0) .* 10.0^i
+            ticks = optimize_ticks(x, y)[1]
+            test_ticks(x, y, ticks)
+        end
     end
 end
 


### PR DESCRIPTION
Undoes part of #83, to correctly compute the number of significant digits.
Before:
```
plot(15:24,1:10)
xlims!(14,25)
```
![tmp](https://user-images.githubusercontent.com/4170948/80613457-fe2d9c80-8a45-11ea-9999-3185eb3c13f2.png)
After:
![tmp](https://user-images.githubusercontent.com/4170948/80613553-1bfb0180-8a46-11ea-8440-2010ffc60e32.png)

This should fix #86, though I can't verify that right now, because when I run `Plots` tests locally it fails due to missing `ImageIO`.