### PR TITLE
pre-compute and store the default ColorScheme

### DIFF
--- a/src/PlotUtils.jl
+++ b/src/PlotUtils.jl
@@ -40,8 +40,6 @@ export
 
 include("ticks.jl")
 
-function __init__()
-
-end
+const _default_colorscheme = generate_colorscheme()
 
 end # module

--- a/src/colorschemes.jl
+++ b/src/colorschemes.jl
@@ -306,7 +306,7 @@ function get_colorscheme(sym::Symbol)
     end
     sym = get(COLORSCHEME_ALIASES, sym, sym)
     if sym === :default || sym === :auto
-        generate_colorscheme()
+        _default_colorscheme
     elseif haskey(ColorSchemes.colorschemes, sym)
         ColorSchemes.colorschemes[sym]
     else


### PR DESCRIPTION
This cuts more than 1 second off the time to first plot. `generate_colorscheme` is fairly complex, but for many calls to `plot` it just returns the same default structure, so we can avoid compiling and running it. My only question is whether a `ColorScheme` is ever mutated; if so we can add a `copy` method.