### PR TITLE
Fix inexact error in zscale

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PlotUtils"
 uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
-version = "1.0.5"
+version = "1.0.6"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/src/intervals.jl
+++ b/src/intervals.jl
@@ -98,7 +98,7 @@ function zscale(
     vmax = last(samples)
 
     # fit a line to the sorted samples
-    min_pix = max(min_npixels, Int(N * max_reject))
+    min_pix = max(min_npixels, round(Int, N * max_reject))
     x = 0:N - 1
 
     ngood = N


### PR DESCRIPTION
- allow rounding of ints for min_pix in zscale
- bump project version 1.0.5 -> 1.0.6

Noticed this bug in the wild while trying to make a plot. There should be no problems in terms of the calculations for switching from `Int()` to `round(Int, )`. It would be nice if there was a regression test for this, but I'm not exactly sure how to reproduce it besides using the precise input I had.

The failure happened when the length of the samples was odd, e.g. 999 forcing `N * max_reject` to be `499.5` which throws an InexactError
