### PR TITLE
Linearize the dispatch for cgrad and add a couple of precompiles

### DIFF
--- a/src/PlotUtils.jl
+++ b/src/PlotUtils.jl
@@ -1,6 +1,3 @@
-
-__precompile__()
-
 module PlotUtils
 
 using ColorSchemes
@@ -41,5 +38,10 @@ export
 include("ticks.jl")
 
 const _default_colorscheme = generate_colorscheme()
+
+if Base.VERSION >= v"1.4.2"
+    include("precompile.jl")
+    _precompile_()
+end
 
 end # module

--- a/src/colorschemes.jl
+++ b/src/colorschemes.jl
@@ -187,17 +187,13 @@ If `rev` is `true` colors are reversed.
 If `alpha` is set, it is applied to all colors.
 """
 function cgrad(
-    colors,
+    colors::ColorScheme,
     values;
     categorical = nothing,
     scale = nothing,
     rev = false,
     alpha = nothing,
 )
-    if colors === :default
-        colors = :inferno
-    end
-    colors = get_colorscheme(colors)
     if categorical !== nothing
         colors, values = prepare_categorical_cgrad_colors(colors, values)
     end
@@ -231,17 +227,16 @@ function cgrad(
     end
 end
 
-function cgrad(colors, n::Int; categorical = nothing, kwargs...)
+function cgrad(colors::ColorScheme, n::Int=length(colors); categorical = nothing, kwargs...)
     values = get_range(n + (categorical !== nothing))
     return cgrad(colors, values; categorical = categorical, kwargs...)
 end
 
-function cgrad(colors; kwargs...)
+function cgrad(colors, args...; kwargs...)
     if colors === :default
         colors = :inferno
     end
-    colors = get_colorscheme(colors)
-    return cgrad(colors, length(colors); kwargs...)
+    return cgrad(get_colorscheme(colors), args...; kwargs...)
 end
 
 cgrad(; kw...) = cgrad(DEFAULT_COLOR_GRADIENT[]; kw...)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,18 @@
+function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    @assert precompile(Tuple{Core.kwftype(typeof(optimize_ticks)),NamedTuple{(:k_min, :k_max),Tuple{Int,Int}},typeof(optimize_ticks),Float64,Float64})
+    for C in (RGB, RGBA), T in (Colors.FixedPointNumbers.N0f8, Float32, Float64)
+        @assert precompile(cgrad, (ColorScheme{Vector{C{T}},String,String},))
+        for V in (Vector{Float64}, typeof(get_range(3)))
+            @assert precompile(cgrad, (ColorScheme{Vector{C{T}},String,String}, V))
+            @assert precompile(CategoricalColorGradient, (ColorScheme{Vector{C{T}},String,String}, V))
+            @assert precompile(ContinuousColorGradient, (ColorScheme{Vector{C{T}},String,String}, V))
+        end
+    end
+    for T in (Float64, Int)
+        @assert precompile(zscale, (Vector{T},))
+    end
+    @assert precompile(optimize_ticks, (Int, Int))
+    @assert precompile(optimize_datetime_ticks, (Int, Int))
+    @assert precompile(adapted_grid, (Function, Tuple{Int,Int}))
+end


### PR DESCRIPTION
https://github.com/JuliaPlots/AbstractPlotting.jl/pull/502

The linearization was mostly to make the sequence clearer so that fewer specializations would likely be needed.