### PR TITLE
Make adapted_grid method more reusable

### DIFF
--- a/src/adapted_grid.jl
+++ b/src/adapted_grid.jl
@@ -9,18 +9,16 @@ where the second derivative is approximated to be large. When an interval
 becomes "straight enough" it is no longer divided. Functions are evaluated at the end points of the intervals.
 
 The parameter `max_recusions` computes how many times each interval is allowed to
-be refined.
+be refined while `max_curvature` specifies below which value of the curvature 
+an interval does not need to be refined further.
 """
-function adapted_grid(f, minmax::Tuple{Real, Real}; max_recursions = 7)
+function adapted_grid(f, minmax::Tuple{Real, Real}; max_recursions = 7, max_curvature = 0.05)
     if minmax[1] > minmax[2]
         throw(ArgumentError("interval must be given as (min, max)"))
     elseif minmax[1] == minmax[2]
         x = minmax[1]
         return [x], [f(x)]
-    end
-
-    # When an interval has curvature smaller than this, stop refining it.
-    max_curvature = 0.05
+    end    
 
     # Initial number of points
     n_points = 21


### PR DESCRIPTION
This is a nice piece of code. Allowing for control over the desired curvature would allow people to reuse this method in many more scenarios without having to copy and paste it to change only a single line.