### PR TITLE
bump ColorSchemes.jl dependency due to precompile

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-ColorSchemes = "3.7"
+ColorSchemes = "3.8"
 Colors = "0.12"
 Reexport = "0.2"
 julia = "1"


### PR DESCRIPTION
ColorScheme is not parameterized (as in lines 5 and 7 of src/precompile.jl) until v3.8, so this causes an error on load for Julia >=v1.4.2 in projects that are restricting ColorSchemes to 3.7.

Error looks like:
~~~julia
ERROR: LoadError: TypeError: in Type{...} expression, expected UnionAll, got Type{ColorSchemes.ColorScheme}
Stacktrace:
 [1] _precompile_() at /root/.julia/packages/PlotUtils/3Ttrk/src/precompile.jl:5
 [2] top-level scope at /root/.julia/packages/PlotUtils/3Ttrk/src/PlotUtils.jl:44
 [3] include(::Function, ::Module, ::String) at ./Base.jl:380
 [4] include(::Module, ::String) at ./Base.jl:368
 [5] top-level scope at none:2
 [6] eval at ./boot.jl:331 [inlined]
 [7] eval(::Expr) at ./client.jl:467
 [8] top-level scope at ./none:3
in expression starting at /root/.julia/packages/PlotUtils/3Ttrk/src/PlotUtils.jl:42
ERROR: Failed to precompile PlotUtils [995b91a9-d308-5afd-9ec6-746e21dbc043] to /root/.julia/compiled/v1.5/PlotUtils/YveHG_XgY6Z.ji.
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] compilecache(::Base.PkgId, ::String) at ./loading.jl:1305
 [3] _require(::Base.PkgId) at ./loading.jl:1030
 [4] require(::Base.PkgId) at ./loading.jl:928
 [5] require(::Module, ::Symbol) at ./loading.jl:923
~~~