### PR TITLE
:diverging colorscheme alias

### DIFF
--- a/src/colorschemes.jl
+++ b/src/colorschemes.jl
@@ -403,6 +403,7 @@ const COLORSCHEME_ALIASES = Dict{Symbol, Symbol}(
     :kg => :linear_ternary_green_0_46_c42_n256,
     :kgy => :linear_green_5_95_c69_n256,
     :kr => :linear_ternary_red_0_50_c52_n256,
+    :diverging => :diverging_bwr_40_95_c42_n256,
     :cyclic1 => :cyclic_mrybm_35_75_c68_n256,
     :cyclic2 => :cyclic_mygbm_30_95_c78_n256,
     :cyclic3 => :cyclic_wrwbw_40_90_c42_n256,


### PR DESCRIPTION
`:diverging` as a colormap name used to work in the past. Maybe it got lost in the transition to `ColorSchemes.jl`.
I didn't check which exact colormap `:diverging` used to be, but I think this one is a reasonable default.