### PR TITLE
Fix: adapted grid to work with Number

### DIFF
--- a/src/adapted_grid.jl
+++ b/src/adapted_grid.jl
@@ -12,7 +12,7 @@ The parameter `max_recusions` computes how many times each interval is allowed t
 be refined while `max_curvature` specifies below which value of the curvature 
 an interval does not need to be refined further.
 """
-function adapted_grid(f, minmax::Tuple{T,T}; max_recursions = 7, max_curvature = 0.05) where {T<:Number}
+function adapted_grid(f, minmax::Tuple{Number, Number}; max_recursions = 7, max_curvature = 0.05)
     if minmax[1] > minmax[2]
         throw(ArgumentError("interval must be given as (min, max)"))
     elseif minmax[1] == minmax[2]

--- a/src/adapted_grid.jl
+++ b/src/adapted_grid.jl
@@ -12,7 +12,7 @@ The parameter `max_recusions` computes how many times each interval is allowed t
 be refined while `max_curvature` specifies below which value of the curvature 
 an interval does not need to be refined further.
 """
-function adapted_grid(f, minmax::Tuple{Real, Real}; max_recursions = 7, max_curvature = 0.05)
+function adapted_grid(f, minmax::Tuple{T,T}; max_recursions = 7, max_curvature = 0.05) where {T<:Number}
     if minmax[1] > minmax[2]
         throw(ArgumentError("interval must be given as (min, max)"))
     elseif minmax[1] == minmax[2]


### PR DESCRIPTION
This PR simply extends the type of the (min, max)-tuple argument for the `adaptive_grid` to accept `Number`s instead of just `Real`s. The goal is to fix https://github.com/jw3126/UnitfulRecipes.jl/issues/36 🙂.

For example, with this PR, this MWE
```julia
using Unitful: m
using Plots, UnitfulRecipes
f(x) = sin(x / m)
plot(f, -5m, 5m)
```
would give
<img width=66% alt="Screen Shot 2021-01-06 at 10 42 03 am" src="https://user-images.githubusercontent.com/4486578/103711549-d26aa980-500b-11eb-8997-699d15e5ad40.png">
which otherwise currently throws a 
```julia
MethodError: no method matching adapted_grid(..., ::Tuple{Quantity, Quantity})
```
on master. 

Hopefully, this PR does not break anything since it's a tiny edit! (I have not run tests locally so waiting to see the CI runs... 😁)
