### PR TITLE
use StableRNGs for tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,8 +18,9 @@ Reexport = "0.2, 1.0"
 julia = "1"
 
 [extras]
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Statistics"]
+test = ["Test", "StableRNGs", "Statistics"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -181,8 +181,8 @@ end
     data[defects] .= rand(rng, [0, 1e7], 500)
     cmin, cmax = zscale(data)
     # values calculated using IRAF
-    @test cmin ≈ 2823.715 atol = 1e-3
-    @test cmax ≈ 4185.414 atol = 1e-3
+    @test cmin ≈ 2841.586 atol = 1e-3
+    @test cmax ≈ 4171.648 atol = 1e-3
     @test cmin > minimum(data)
     @test cmax < maximum(data)
 


### PR DESCRIPTION
This adds StableRNGs.jl as a test dependency and updates all `rand*` calls to use the seeded RNG.

This also updates the test values for `zscale` after recalculating.

fixes #111