### PR TITLE
do not specialize on the function in adapted_grid

### DIFF
--- a/src/adapted_grid.jl
+++ b/src/adapted_grid.jl
@@ -9,16 +9,16 @@ where the second derivative is approximated to be large. When an interval
 becomes "straight enough" it is no longer divided. Functions are evaluated at the end points of the intervals.
 
 The parameter `max_recusions` computes how many times each interval is allowed to
-be refined while `max_curvature` specifies below which value of the curvature 
+be refined while `max_curvature` specifies below which value of the curvature
 an interval does not need to be refined further.
 """
-function adapted_grid(f, minmax::Tuple{Number, Number}; max_recursions = 7, max_curvature = 0.05)
+function adapted_grid(@nospecialize(f), minmax::Tuple{Number, Number}; max_recursions = 7, max_curvature = 0.05)
     if minmax[1] > minmax[2]
         throw(ArgumentError("interval must be given as (min, max)"))
     elseif minmax[1] == minmax[2]
         x = minmax[1]
         return [x], [f(x)]
-    end    
+    end
 
     # Initial number of points
     n_points = 21


### PR DESCRIPTION
This avoids having to recompile it for all different input functions

Before:

```jl
julia> @time adapted_grid(x->x, (0,1));
  0.748009 seconds (1.60 M allocations: 82.982 MiB, 3.17% gc time, 99.26% compilation time)

julia> @time adapted_grid(x->x, (0,1));
  0.490260 seconds (593.23 k allocations: 30.643 MiB, 16.33% gc time, 99.97% compilation time)

julia> @time adapted_grid(x->x, (0,1));
  0.488363 seconds (593.23 k allocations: 30.639 MiB, 9.39% gc time, 99.97% compilation time)
```

After:

```jl
julia> @time adapted_grid(x->x, (0,1));
  0.732140 seconds (1.04 M allocations: 54.736 MiB, 3.45% gc time, 98.40% compilation time)

julia> @time adapted_grid(x->x, (0,1));
  0.044722 seconds (113.41 k allocations: 6.245 MiB, 99.04% compilation time)

julia> @time adapted_grid(x->x, (0,1));
  0.044496 seconds (113.41 k allocations: 6.246 MiB, 99.29% compilation time)
```