### PR TITLE
Coax compiler to not box `x` in `Base.get(cg::ContinuousColorGradient…

### DIFF
--- a/src/colorschemes.jl
+++ b/src/colorschemes.jl
@@ -62,7 +62,7 @@ function Base.get(cg::ContinuousColorGradient, x::AbstractFloat, rangescale = (0
     if x in v
         index = findfirst(==(x), v)
     else
-        i = findlast(t -> t < x, v)
+        i = findlast(<(x), v)
         r = (x - v[i]) / (v[i + 1] - v[i])
         index = (i + r - 1) / (length(v) - 1)
     end

--- a/src/colorschemes.jl
+++ b/src/colorschemes.jl
@@ -62,7 +62,8 @@ function Base.get(cg::ContinuousColorGradient, x::AbstractFloat, rangescale = (0
     if x in v
         index = findfirst(==(x), v)
     else
-        i = findlast(<(x), v)
+        xx = x # avoid boxing
+        i = findlast(t -> t < xx, v)
         r = (x - v[i]) / (v[i + 1] - v[i])
         index = (i + r - 1) / (length(v) - 1)
     end


### PR DESCRIPTION
```
const g = cgrad(:thermal)
const a = rand(3142, 577)
@btime map(x -> g[x], a)
  7.853 s (265257049 allocations: 4.76 GiB)
@profile map(x -> g[x], a)
```

```
Overhead ╎ [+additional indent] Count File:Line; Function
=========================================================
    ╎3808 @Base\task.jl:411; (::VSCodeServer.var"#53#54")()
   3╎    ╎    ╎    ╎    3764 @PlotUtils\src\colorschemes.jl:54; get
    ╎    ╎    ╎    ╎     3105 @PlotUtils\src\colorschemes.jl:65; get(cg::PlotUtils.ContinuousColorGradient, x::Float64, rangescale::Tuple{Flo...
    ╎    ╎    ╎    ╎    ╎ 3105 @Base\array.jl:2099; findlast
  95╎    ╎    ╎    ╎    ╎  3105 @Base\array.jl:2051; findprev
2880╎    ╎    ╎    ╎    ╎   2952 @PlotUtils\src\colorschemes.jl:65; (::PlotUtils.var"#8#9")(t::Float64)
  72╎    ╎    ╎    ╎    ╎    72   @Base\float.jl:371; <(x::Float64, y::Float64)


Base.get(cg::ContinuousColorGradient, x::AbstractFloat, rangescale = (0.0, 1.0))
```

For some reason it looks like `x` is being boxed. This change convinces the compiler to not box it, leading to a sizeable improvement:

```
@btime map(x -> g[x], a)
  1.174 s (25425068 allocations: 1.19 GiB)
```