### PR TITLE
Fix type instability regression

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PlotUtils"
 uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"


### PR DESCRIPTION
Fix type instability regression introduced in https://github.com/JuliaPlots/PlotUtils.jl/pull/124.

```julia
using PlotUtils
f() = PlotUtils.optimize_ticks(0.25314125, 0.94421935, k_min = 4, k_max = 8)
f()
@time f()
```

**Before**
`0.009535 seconds (101.74 k allocations: 1.942 MiB)`
**After**
`  0.004151 seconds (36.46 k allocations: 694.031 KiB)`