### PR TITLE
Fix optimize_datetime_ticks on 32bit systems again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,13 @@ jobs:
           - macos-latest
         arch:
           - x64
-          # - x86
+          - x86
+        exclude:
+          # Test 32-bit only on Linux
+          - os: macos-latest
+            arch: x86
+          - os: windows-latest
+            arch: x86
         include:
           - version: 'nightly'
             os: ubuntu-latest

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -566,8 +566,9 @@ end
 # Choose "round" (full seconds/minutes/hours/days/months/years) DateTime ticks
 # between x_min and x_max:
 function optimize_datetime_ticks(a_min, a_max; k_min = 2, k_max = 4)
-    x_min = DateTime(Dates.UTM(Int(round(a_min))))
-    x_max = DateTime(Dates.UTM(Int(round(a_max))))
+    # Int64 is needed here for 32bit systems
+    x_min = DateTime(Dates.UTM(Int64(round(a_min))))
+    x_max = DateTime(Dates.UTM(Int64(round(a_max))))
 
     Δt = x_max - x_min
     if Δt > Dates.Day(365k_min)


### PR DESCRIPTION
Reintroduces part of #80, which were rolled back in #124 causing a regression in 32bit systems. See for instance https://github.com/invenia/Intervals.jl/pull/186.