### PR TITLE
jk/speed up optimize ticks

### DIFF
--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -231,7 +231,7 @@ function optimize_ticks_typed(
 
                 r = (x_max - span) / tickspan
                 isfinite(r) || continue
-                r = ceil(Int, r)
+                r = ceil(r)
 
                 # try to favor integer exponents for log scales
                 if is_log_scale && !isinteger(tickspan)

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -185,8 +185,7 @@ function optimize_ticks_typed(
     span_buffer,
     scale,
 ) where {F}
-    xspan = x_max - x_min
-    if xspan < eps(F)
+    if (xspan = x_max - x_min) < eps(F)
         return fallback_ticks(x_min, x_max, k_min, k_max)
     end
 

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -321,11 +321,6 @@ function optimize_ticks_typed(
                     end
 
                     if score > high_score && (k_min <= len_S_view <= k_max)
-                        # if strict_span
-                        #     # make S a copy because it is a view and
-                        #     # could otherwise be mutated in the next runs
-                        #     S = collect(S_view)
-                        # end
                         viewmin_best, viewmax_best = viewmin, viewmax
                         # overwrite S_best with S_view
                         copy!(S_best, S_view)
@@ -362,7 +357,7 @@ function optimize_ticks_typed(
         end
     end
 
-    return collect(S_best), viewmin_best, viewmax_best
+    return S_best, viewmin_best, viewmax_best
 end
 
 optimize_ticks(

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -212,8 +212,8 @@ function optimize_ticks_typed(
     end
 
     high_score = -Inf
-    # create an initial view for S_best for type stability, this will not be used otherwise
-    S_best = Vector{F}(undef, 1)
+    # preallocate S_best
+    S_best = Vector{F}(undef, k_max)
     viewmin_best, viewmax_best = x_min, x_max
 
     # we preallocate arrays that hold all required S arrays for every given

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -185,7 +185,8 @@ function optimize_ticks_typed(
     span_buffer,
     scale,
 ) where {F}
-    if (xspan = x_max - x_min) < eps(F)
+    xspan = x_max - x_min
+    if xspan < eps(F)
         return fallback_ticks(x_min, x_max, k_min, k_max)
     end
 
@@ -203,10 +204,12 @@ function optimize_ticks_typed(
     sigdigits(z) = max(1, x_digits - z + q_extra_digits)
 
     ib = Int(base)
-    round_base = (
-        isinteger(base) ? v -> round(v, sigdigits = sigdigits(z), base = ib) :
-        v -> round(v, sigdigits = sigdigits(z))
-    )
+    round_base = let z_ = z
+        (
+            isinteger(base) ? v -> round(v, sigdigits = sigdigits(z_), base = ib) :
+            v -> round(v, sigdigits = sigdigits(z_))
+        )
+    end
 
     high_score = -Inf
     # create an initial view for S_best for type stability, this will not be used otherwise


### PR DESCRIPTION
- make S_view type stable
- fix boxing type-instability with `let`
- one more type instability

I timed with this:

```julia
@btime PlotUtils.optimize_ticks_typed(
    0.1123, 100.132, false,
    $([(1.0, 1.0), (5.0, 0.9), (2.0, 0.7), (2.5, 0.5), (3.0, 0.2)]),
    2,
    10,
    5,
    1 / 4,
    1 / 6,
    1 / 3,
    1 / 4,
    true,
    nothing,
    nothing,
)
```

And got the following timings:

| before | after |
| -- | -- |
| 5.406 ms (95897 allocations: 1.76 MiB) | 360.978 μs (23 allocations: 3.17 KiB) |

That's 15 times faster.

Should help quite a bit with the slowness that motivated this PR https://github.com/JuliaPlots/Makie.jl/pull/1612

Makes zooming in an Axis go from very choppy to smooth on my macbook.

