### PR TITLE
Speedup `optimize_ticks` algorithm, reduce allocations - update tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,8 @@
 *.jl.*.cov
 *.jl.mem
 Manifest.toml
+
+*.cov
+*.mem
+
 dev/ 

--- a/src/PlotUtils.jl
+++ b/src/PlotUtils.jl
@@ -36,11 +36,13 @@ include("ticks.jl")
 
 const _default_colorscheme = generate_colorscheme()
 
-if Base.VERSION >= v"1.4.2"
-    include("precompile.jl")
-    # optimize_ticks(0., 100.)
-    # optimize_ticks(0, 100)
-    _precompile_()
+# NOTE: allocation issues, see comments on github.com/JuliaPlots/PlotUtils.jl/pull/136
+# try to restore on 1.8 after proper regression analysis
+@static if false
+    if Base.VERSION >= v"1.4.2"
+        include("precompile.jl")
+        _precompile_()
+    end
 end
 
 end # module

--- a/src/PlotUtils.jl
+++ b/src/PlotUtils.jl
@@ -38,6 +38,8 @@ const _default_colorscheme = generate_colorscheme()
 
 if Base.VERSION >= v"1.4.2"
     include("precompile.jl")
+    # optimize_ticks(0., 100.)
+    # optimize_ticks(0, 100)
     _precompile_()
 end
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,6 +1,5 @@
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-    #=
     @assert precompile(
         Tuple{
             Core.kwftype(typeof(optimize_ticks)),
@@ -12,7 +11,6 @@ function _precompile_()
     )
     @assert precompile(optimize_ticks, (Int, Int))
     @assert precompile(optimize_datetime_ticks, (Int, Int))
-    =#
     for C in (RGB, RGBA), T in (Colors.FixedPointNumbers.N0f8, Float32, Float64)
         @assert precompile(cgrad, (ColorScheme{Vector{C{T}},String,String},))
         for V in (Vector{Float64}, typeof(get_range(3)))

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,5 +1,6 @@
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    #=
     @assert precompile(
         Tuple{
             Core.kwftype(typeof(optimize_ticks)),
@@ -9,6 +10,9 @@ function _precompile_()
             Float64,
         },
     )
+    @assert precompile(optimize_ticks, (Int, Int))
+    @assert precompile(optimize_datetime_ticks, (Int, Int))
+    =#
     for C in (RGB, RGBA), T in (Colors.FixedPointNumbers.N0f8, Float32, Float64)
         @assert precompile(cgrad, (ColorScheme{Vector{C{T}},String,String},))
         for V in (Vector{Float64}, typeof(get_range(3)))
@@ -26,7 +30,5 @@ function _precompile_()
     for T in (Float64, Int)
         @assert precompile(zscale, (Vector{T},))
     end
-    @assert precompile(optimize_ticks, (Int, Int))
-    @assert precompile(optimize_datetime_ticks, (Int, Int))
     @assert precompile(adapted_grid, (Function, Tuple{Int,Int}))
 end

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -228,21 +228,18 @@ function optimize_ticks_typed(
         maximum(postdecimal_digits(q) for q in Qv)
     )
 
-    high_score = -Inf
-    S_best = Vector{F}(undef, k_max)
     viewmin_best, viewmax_best = x_min, x_max
+    high_score = -Inf
 
-    # we preallocate arrays that hold all required S arrays for every given
-    # the k parameter, so we don't have to create them again and again, which
-    # saves many allocations
-    prealloc_Ss = [Vector{F}(undef, extend_ticks ? Int(3k) : k) for k in k_min:(2k_max)]
-
+    S_best = Vector{F}(undef, k_max)
     len_S_best = length(S_best)
+
+    S = Vector{F}(undef, extend_ticks ? 6k_max : 2k_max)
+
     @inbounds begin
         while 2k_max * base_float^(z + 1) > xspan
             sigdigits::Int = max(1, num_digits - z)
             for k in k_min:(2k_max)
-                S = prealloc_Ss[k - k_min + 1]
                 for (q, qscore) in zip(Qv, Qs)
                     tickspan = q * base_float^z
                     tickspan < eps(F) && continue

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -160,8 +160,8 @@ function optimize_ticks(
     Qv = F[q[1] for q in Q]
     Qs = F[q[2] for q in Q]
 
-    base_untyped = F(get(_logScaleBases, scale, 10.0))
-    base = isinteger(base_untyped) && base_untyped != 10.0 ? Int(base_untyped) : nothing
+    base_float = F(get(_logScaleBases, scale, 10.0))
+    base = isinteger(base_float) ? Int(base_float) : 10
     is_log_scale = scale ∈ _logScales
 
     for i in 1:2
@@ -182,6 +182,7 @@ function optimize_ticks(
             sspan,
             span_buffer,
             is_log_scale,
+            base_float,
             base,
         )
 
@@ -213,9 +214,9 @@ function optimize_ticks_typed(
     strict_span::Bool,
     span_buffer,
     is_log_scale::Bool,
-    base::Union{Nothing,Integer},
+    base_float::F,
+    base::Integer,
 ) where {F<:AbstractFloat}
-    base_float = F(base === nothing ? 10 : base)
     xspan = x_max - x_min
 
     # generalizing "order of magnitude"

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -141,9 +141,9 @@ function optimize_ticks(
     x_max::T;
     extend_ticks::Bool = false,
     Q = [(1.0, 1.0), (5.0, 0.9), (2.0, 0.7), (2.5, 0.5), (3.0, 0.2)],
-    k_min::Int = 2,
-    k_max::Int = 10,
-    k_ideal::Int = 5,
+    k_min::Integer = 2,
+    k_max::Integer = 10,
+    k_ideal::Integer = 5,
     granularity_weight::Float64 = 1 / 4,
     simplicity_weight::Float64 = 1 / 6,
     coverage_weight::Float64 = 1 / 3,
@@ -202,8 +202,8 @@ function optimize_ticks_typed(
     x_min::F,
     x_max::F,
     extend_ticks,
-    Qv::AbstractVector,
-    Qs::AbstractVector,
+    Qv,
+    Qs,
     k_min,
     k_max,
     k_ideal,
@@ -211,9 +211,9 @@ function optimize_ticks_typed(
     simplicity_weight::F,
     coverage_weight::F,
     niceness_weight::F,
-    strict_span::Bool,
+    strict_span,
     span_buffer,
-    is_log_scale::Bool,
+    is_log_scale,
     base_float::F,
     base::Integer,
 ) where {F<:AbstractFloat}
@@ -235,7 +235,7 @@ function optimize_ticks_typed(
     S_best = Vector{F}(undef, k_max)
     len_S_best = length(S_best)
 
-    S = Vector{F}(undef, extend_ticks ? 4k_max : 2k_max)
+    S = Vector{F}(undef, (extend_ticks ? 4 : 2) * k_max)
 
     @inbounds begin
         while 2k_max * base_float^(z + 1) > xspan
@@ -252,12 +252,7 @@ function optimize_ticks_typed(
                     r = ceil(Int, r_float)
 
                     # try to favor integer exponents for log scales
-                    if is_log_scale && !isinteger(tickspan)
-                        nice_scale = false
-                        qscore = 0.0
-                    else
-                        nice_scale = true
-                    end
+                    (nice_scale = !is_log_scale || isinteger(tickspan)) || (qscore = F(0))
 
                     while r * tickspan <= x_min
                         # Filter or expand ticks

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -234,7 +234,7 @@ function optimize_ticks_typed(
     S_best = Vector{F}(undef, k_max)
     len_S_best = length(S_best)
 
-    S = Vector{F}(undef, extend_ticks ? 6k_max : 2k_max)
+    S = Vector{F}(undef, extend_ticks ? 4k_max : 2k_max)
 
     @inbounds begin
         while 2k_max * base_float^(z + 1) > xspan
@@ -290,7 +290,7 @@ function optimize_ticks_typed(
 
                             # we do this because it saves allocations and leaves S type stable
                             counter = 0
-                            for i in 1:length(S)
+                            for i in 1:imax
                                 if (viewmin - buf) <= S[i] <= (viewmax + buf)
                                     counter += 1
                                     S[counter] = S[i]
@@ -298,7 +298,7 @@ function optimize_ticks_typed(
                             end
                             len = counter
                         else
-                            len = length(S)
+                            len = imax
                         end
 
                         # evaluate quality of ticks

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -219,11 +219,11 @@ function optimize_ticks_typed(
     xspan = x_max - x_min
 
     # generalizing "order of magnitude"
-    z::Int = bounding_order_of_magnitude(xspan, base_float)
+    z = bounding_order_of_magnitude(xspan, base_float)
 
     # find required significant digits for ticks with q * base^z spacing,
     # for q values specified in Qv
-    num_digits::Int = (
+    num_digits = (
         bounding_order_of_magnitude(max(abs(x_min), abs(x_max)), base_float) +
         maximum(postdecimal_digits(q) for q in Qv)
     )
@@ -238,7 +238,7 @@ function optimize_ticks_typed(
 
     @inbounds begin
         while 2k_max * base_float^(z + 1) > xspan
-            sigdigits::Int = max(1, num_digits - z)
+            sigdigits = max(1, num_digits - z)
             for k in k_min:(2k_max)
                 for (q, qscore) in zip(Qv, Qs)
                     tickspan = q * base_float^z

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -340,8 +340,8 @@ function optimize_ticks_typed(
             z -= 1
         end
     end
-
-    return high_score, S_best[1:len_S_best], viewmin_best, viewmax_best
+    resize!(S_best, len_S_best)
+    return high_score, S_best, viewmin_best, viewmax_best
 end
 
 optimize_ticks(

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -256,7 +256,7 @@ function optimize_ticks_typed(
                     # try to favor integer exponents for log scales
                     if is_log_scale && !isinteger(tickspan)
                         nice_scale = false
-                        qscore = 0.
+                        qscore = 0.0
                     else
                         nice_scale = true
                     end
@@ -277,8 +277,10 @@ function optimize_ticks_typed(
                             imax = k
                         end
                         # round only those values that end up as viewmin and viewmax to save computation time
-                        S[imin] = viewmin = round(S[imin], sigdigits = sigdigits, base = base)
-                        S[imax] = viewmax = round(S[imax], sigdigits = sigdigits, base = base)
+                        S[imin] =
+                            viewmin = round(S[imin], sigdigits = sigdigits, base = base)
+                        S[imax] =
+                            viewmax = round(S[imax], sigdigits = sigdigits, base = base)
 
                         if strict_span
                             viewmin = max(viewmin, x_min)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -150,55 +150,56 @@ end
             test_ticks(x, y, ticks)
         end
     end
+end
 
-    @testset "issues" begin
-        @testset "PlotUtils.jl/issues/86" begin
-            let x = -1.0, y = 13.0
-                test_ticks(x, y, optimize_ticks(x, y, k_min = 4, k_max = 8)[1])
-            end
-        end
-
-        @testset "Plots.jl/issues/3859" begin
-            x, y = extrema([-1.7055509600077687e307, -1.3055509600077687e307, -1.e300])
+@testset "issues" begin
+    @testset "PlotUtils.jl/issues/86" begin
+        let x = -1.0, y = 13.0
             test_ticks(x, y, optimize_ticks(x, y, k_min = 4, k_max = 8)[1])
         end
+    end
 
-        @testset "PlotUtils.jl/issues/114" begin
-            let x = -0.1eps(), y = 0.1eps()
-                test_ticks(x, y, optimize_ticks(x, y)[1])
-            end
+    @testset "Plots.jl/issues/3859" begin
+        x, y = extrema([-1.7055509600077687e307, -1.3055509600077687e307, -1.e300])
+        test_ticks(x, y, optimize_ticks(x, y, k_min = 4, k_max = 8)[1])
+    end
+
+    @testset "PlotUtils.jl/issues/114" begin
+        let x = -0.1eps(), y = 0.1eps()
+            test_ticks(x, y, optimize_ticks(x, y)[1])
         end
+    end
 
-        @testset "PlotUtils.jl/issues/116" begin
-            let x = 4.5, y = 5.5
-                test_ticks(x, y, optimize_ticks(x, y, scale = :log10)[1])
-            end
-            let x = 2.5, y = 3.5
-                test_ticks(x, y, optimize_ticks(x, y, scale = :log2)[1])
-            end
+    @testset "PlotUtils.jl/issues/116" begin
+        let x = 4.5, y = 5.5
+            test_ticks(x, y, optimize_ticks(x, y, scale = :log10)[1])
         end
+        let x = 2.5, y = 3.5
+            test_ticks(x, y, optimize_ticks(x, y, scale = :log2)[1])
+        end
+    end
 
-        @testset "PlotUtils.jl/issues/129" begin
-            # invalid float input
-            let x = NaN, y = 1.0
-                ticks, = optimize_ticks(x, y)
-                @test isnan(ticks[1])
-                @test ticks[2] === y
-                ticks, = optimize_ticks(x, y, k_min = 5)
-                @test isnan(ticks[1])
-                @test ticks[2] === y
-            end
-            let x = 0.0f0, y = Inf32
-                ticks, = optimize_ticks(x, y)
-                @test ticks[1] === x
-                @test isinf(ticks[2])
-                ticks, = optimize_ticks(x, y, k_min = 5)
-                @test ticks[1] === x
-                @test isinf(ticks[2])
-            end
+    @testset "PlotUtils.jl/issues/129" begin
+        # invalid float input
+        let x = NaN, y = 1.0
+            ticks, = optimize_ticks(x, y)
+            @test isnan(ticks[1])
+            @test ticks[2] === y
+            ticks, = optimize_ticks(x, y, k_min = 5)
+            @test isnan(ticks[1])
+            @test ticks[2] === y
+        end
+        let x = 0.0f0, y = Inf32
+            ticks, = optimize_ticks(x, y)
+            @test ticks[1] === x
+            @test isinf(ticks[2])
+            ticks, = optimize_ticks(x, y, k_min = 5)
+            @test ticks[1] === x
+            @test isinf(ticks[2])
         end
     end
 end
+
 
 # ----------------------
 # adapted grid

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -250,3 +250,10 @@ end
     @test cmin == 0
     @test cmax == 999
 end
+
+@testset "allocations" begin
+    # PlotUtils.jl/pull/136
+    stats = @timed PlotUtils.optimize_ticks(0.1123, 100.132)
+    @test stats.bytes < 1_000  # ~ 816
+    @test stats.time < 5e-3  # ~ 1.35ms
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ using Random
 using StableRNGs
 
 rng = StableRNG(42)
+warn_ticks = :warn, "No strict ticks found"
 
 # ----------------------
 # colors
@@ -109,7 +110,7 @@ end
         @testset "small range $x, $(i)ϵ" for x in exp10.(-12:12), i in -5:5
             y = x + i * eps(x)
             x, y = minmax(x, y)
-            ticks, = PlotUtils.optimize_ticks(x, y)
+            ticks, = optimize_ticks(x, y)
             @test issorted(ticks)
             @test all(x .<= ticks .<= y)
             # Fails:
@@ -176,7 +177,7 @@ end
             let x = 2.5, y = 3.5
                 test_ticks(x, y, optimize_ticks(x, y, scale = :log2)[1])
             end
-            let x = .5, y = 1.5
+            let x = 0.5, y = 1.5
                 test_ticks(x, y, optimize_ticks(x, y, scale = :ln)[1])
             end
         end
@@ -184,18 +185,18 @@ end
         @testset "PlotUtils.jl/issues/129" begin
             # invalid float input
             let x = NaN, y = 1.0
-                ticks, = optimize_ticks(x, y)
+                ticks, = @test_logs warn_ticks optimize_ticks(x, y)
                 @test isnan(ticks[1])
                 @test ticks[2] === y
-                ticks, = optimize_ticks(x, y, k_min = 5)
+                ticks, = @test_logs warn_ticks optimize_ticks(x, y, k_min = 5)
                 @test isnan(ticks[1])
                 @test ticks[2] === y
             end
             let x = 0.0f0, y = Inf32
-                ticks, = optimize_ticks(x, y)
+                ticks, = @test_logs warn_ticks optimize_ticks(x, y)
                 @test ticks[1] === x
                 @test isinf(ticks[2])
-                ticks, = optimize_ticks(x, y, k_min = 5)
+                ticks, = @test_logs warn_ticks optimize_ticks(x, y, k_min = 5)
                 @test ticks[1] === x
                 @test isinf(ticks[2])
             end
@@ -254,9 +255,8 @@ end
     @test cmax == 999
 end
 
-@testset "allocations" begin
-    # PlotUtils.jl/pull/136
-    stats = @timed PlotUtils.optimize_ticks(0.1123, 100.132)
+@testset "allocations" begin  # see PlotUtils.jl/pull/136
+    stats = @timed optimize_ticks(0.1123, 100.132)
     @test stats.bytes < 1_000  # ~ 816
-    @test stats.time < 5e-3  # ~ 1.35ms
+    @test stats.time < 1e-3  # ~ 4.5µs
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -150,56 +150,55 @@ end
             test_ticks(x, y, ticks)
         end
     end
-end
 
-@testset "issues" begin
-    @testset "PlotUtils.jl/issues/86" begin
-        let x = -1.0, y = 13.0
+    @testset "issues" begin
+        @testset "PlotUtils.jl/issues/86" begin
+            let x = -1.0, y = 13.0
+                test_ticks(x, y, optimize_ticks(x, y, k_min = 4, k_max = 8)[1])
+            end
+        end
+
+        @testset "Plots.jl/issues/3859" begin
+            x, y = extrema([-1.7055509600077687e307, -1.3055509600077687e307, -1.e300])
             test_ticks(x, y, optimize_ticks(x, y, k_min = 4, k_max = 8)[1])
         end
-    end
 
-    @testset "Plots.jl/issues/3859" begin
-        x, y = extrema([-1.7055509600077687e307, -1.3055509600077687e307, -1.e300])
-        test_ticks(x, y, optimize_ticks(x, y, k_min = 4, k_max = 8)[1])
-    end
+        @testset "PlotUtils.jl/issues/114" begin
+            let x = -0.1eps(), y = 0.1eps()
+                test_ticks(x, y, optimize_ticks(x, y)[1])
+            end
+        end
 
-    @testset "PlotUtils.jl/issues/114" begin
-        let x = -0.1eps(), y = 0.1eps()
-            test_ticks(x, y, optimize_ticks(x, y)[1])
+        @testset "PlotUtils.jl/issues/116" begin
+            let x = 4.5, y = 5.5
+                test_ticks(x, y, optimize_ticks(x, y, scale = :log10)[1])
+            end
+            let x = 2.5, y = 3.5
+                test_ticks(x, y, optimize_ticks(x, y, scale = :log2)[1])
+            end
         end
-    end
 
-    @testset "PlotUtils.jl/issues/116" begin
-        let x = 4.5, y = 5.5
-            test_ticks(x, y, optimize_ticks(x, y, scale = :log10)[1])
-        end
-        let x = 2.5, y = 3.5
-            test_ticks(x, y, optimize_ticks(x, y, scale = :log2)[1])
-        end
-    end
-
-    @testset "PlotUtils.jl/issues/129" begin
-        # invalid float input
-        let x = NaN, y = 1.0
-            ticks, = optimize_ticks(x, y)
-            @test isnan(ticks[1])
-            @test ticks[2] === y
-            ticks, = optimize_ticks(x, y, k_min = 5)
-            @test isnan(ticks[1])
-            @test ticks[2] === y
-        end
-        let x = 0.0f0, y = Inf32
-            ticks, = optimize_ticks(x, y)
-            @test ticks[1] === x
-            @test isinf(ticks[2])
-            ticks, = optimize_ticks(x, y, k_min = 5)
-            @test ticks[1] === x
-            @test isinf(ticks[2])
+        @testset "PlotUtils.jl/issues/129" begin
+            # invalid float input
+            let x = NaN, y = 1.0
+                ticks, = optimize_ticks(x, y)
+                @test isnan(ticks[1])
+                @test ticks[2] === y
+                ticks, = optimize_ticks(x, y, k_min = 5)
+                @test isnan(ticks[1])
+                @test ticks[2] === y
+            end
+            let x = 0.0f0, y = Inf32
+                ticks, = optimize_ticks(x, y)
+                @test ticks[1] === x
+                @test isinf(ticks[2])
+                ticks, = optimize_ticks(x, y, k_min = 5)
+                @test ticks[1] === x
+                @test isinf(ticks[2])
+            end
         end
     end
 end
-
 
 # ----------------------
 # adapted grid

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -176,6 +176,9 @@ end
             let x = 2.5, y = 3.5
                 test_ticks(x, y, optimize_ticks(x, y, scale = :log2)[1])
             end
+            let x = .5, y = 1.5
+                test_ticks(x, y, optimize_ticks(x, y, scale = :ln)[1])
+            end
         end
 
         @testset "PlotUtils.jl/issues/129" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -257,6 +257,6 @@ end
 
 @testset "allocations" begin  # see PlotUtils.jl/pull/136
     stats = @timed optimize_ticks(0.1123, 100.132)
-    @test stats.bytes < 1_000  # ~ 816
-    @test stats.time < 1e-3  # ~ 4.5µs
+    @test stats.bytes < 1_000  # ~ 848 (on 1.6)
+    @test stats.time < 1e-3  # ~ 0.45ms (on 1.6)
 end


### PR DESCRIPTION
@jkrumbiegel, this is my attempt at reducing allocs & speedup (extending your ideas from https://github.com/JuliaPlots/PlotUtils.jl/pull/135), with CI passing.

```julia
julia> using BenchmarkTools, PlotUtils
julia> @btime PlotUtils.optimize_ticks(.1123, 100.132);
  2.220 ms (17760 allocations: 280.67 KiB)
```

I still don't understand why `round(...)` allocates. `@code_warntype` does not complain.