### PR TITLE
`adapted_grid`: increase density through reduced `curvature` and increased starting `n_points`

### DIFF
--- a/src/adapted_grid.jl
+++ b/src/adapted_grid.jl
@@ -18,9 +18,8 @@ function adapted_grid(
     minmax::Tuple{Number,Number};
     max_recursions = 7,
     max_curvature = 0.01,
-    n_points = 31
+    n_points = 31,
 )
-
     if minmax[1] > minmax[2]
         throw(ArgumentError("interval must be given as (min, max)"))
     elseif minmax[1] == minmax[2]
@@ -30,7 +29,6 @@ function adapted_grid(
 
     @assert isodd(n_points)
     n_intervals = n_points ÷ 2
-    # @show n_points
 
     xs = collect(range(minmax[1]; stop = minmax[2], length = n_points))
     # Move the first and last interior points a bit closer to the end points
@@ -165,7 +163,6 @@ function adapted_grid(
         n_points = n_points + n_new_points
         n_intervals = n_points ÷ 2
     end
-    # @show n_points
 
     return xs, fs
 end

--- a/src/adapted_grid.jl
+++ b/src/adapted_grid.jl
@@ -1,17 +1,15 @@
 
 """
-    adapted_grid(f, minmax::Tuple{Number, Number}; max_recursions = 7)
+    adapted_grid(f, minmax::Tuple{Number, Number}; max_recursions = 7, max_curvature = 0.01, n_points = 31)
 
 Computes a grid `x` on the interval [minmax[1], minmax[2]] so that `plot(f, x)` gives a smooth "nice" plot.
-The method used is to create an initial uniform grid (31 points) and refine intervals
+The method used is to create an uniform grid with `n_points` initial points and refine intervals
 where the second derivative is approximated to be large.
 When an interval becomes "straight enough" it is no longer divided.
 Functions are evaluated at the end points of the intervals.
 
 The parameter `max_recusions` computes how many times each interval is allowed to be refined
 while `max_curvature` specifies below which value of the curvature an interval does not need to be refined further.
-
-The parameter `n_points` is the initial number of points.
 """
 function adapted_grid(
     @nospecialize(f),
@@ -32,14 +30,14 @@ function adapted_grid(
 
     xs = collect(range(minmax[1]; stop = minmax[2], length = n_points))
     # Move the first and last interior points a bit closer to the end points
-    xs[2] = xs[1] + (xs[2] - xs[1]) * 0.25
-    xs[end - 1] = xs[end] - (xs[end] - xs[end - 1]) * 0.25
+    xs[2] = xs[1] + (xs[2] - xs[1]) / 4
+    xs[end - 1] = xs[end] - (xs[end] - xs[end - 1]) / 4
 
     # Wiggle interior points a bit to prevent aliasing and other degenerate cases
     rng = MersenneTwister(1337)
     rand_factor = 0.05
     for i in 2:(length(xs) - 1)
-        xs[i] += rand_factor * 2 * (rand(rng) - 0.5) * (xs[i + 1] - xs[i - 1])
+        xs[i] += 2rand_factor * (rand(rng) - 0.5) * (xs[i + 1] - xs[i - 1])
     end
 
     n_tot_refinements = zeros(Int, n_intervals)

--- a/src/adapted_grid.jl
+++ b/src/adapted_grid.jl
@@ -3,7 +3,7 @@
     adapted_grid(f, minmax::Tuple{Number, Number}; max_recursions = 7)
 
 Computes a grid `x` on the interval [minmax[1], minmax[2]] so that `plot(f, x)` gives a smooth "nice" plot.
-The method used is to create an initial uniform grid (21 points) and refine intervals
+The method used is to create an initial uniform grid (31 points) and refine intervals
 where the second derivative is approximated to be large.
 When an interval becomes "straight enough" it is no longer divided.
 Functions are evaluated at the end points of the intervals.

--- a/src/adapted_grid.jl
+++ b/src/adapted_grid.jl
@@ -65,9 +65,7 @@ function adapted_grid(
         min_f, max_f = any(isfinite_f) ? extrema(fs[isfinite_f]) : (0.0, 0.0)
         f_range = max_f - min_f
         # Guard against division by zero later
-        if f_range == 0 || !isfinite(f_range)
-            f_range = one(f_range)
-        end
+        (f_range == 0 || !isfinite(f_range)) && (f_range = one(f_range))
         # Skip first and last interval
         for interval in 1:n_intervals
             p = 2interval
@@ -86,16 +84,13 @@ function adapted_grid(
                     i = p + q
                     # Estimate integral of second derivative over interval, use that as a refinement indicator
                     # https://mathformeremortals.wordpress.com/2013/01/12/a-numerical-second-derivative-from-three-points/
+                    δx = xs[i + 1] - xs[i - 1]
                     curvatures[interval] +=
                         abs(
-                            2 *
-                            (
-                                (fs[i + 1] - fs[i]) /
-                                ((xs[i + 1] - xs[i]) * (xs[i + 1] - xs[i - 1])) -
-                                (fs[i] - fs[i - 1]) /
-                                ((xs[i] - xs[i - 1]) * (xs[i + 1] - xs[i - 1]))
-                            ) *
-                            (xs[i + 1] - xs[i - 1])^2,
+                            2(
+                                (fs[i + 1] - fs[i]) / ((xs[i + 1] - xs[i]) * δx) -
+                                (fs[i] - fs[i - 1]) / ((xs[i] - xs[i - 1]) * δx)
+                            ) * δx^2,
                         ) / f_range * w
                 end
                 curvatures[interval] /= tot_w

--- a/test/adaptive_test_functions.jl
+++ b/test/adaptive_test_functions.jl
@@ -1,5 +1,6 @@
 # This is not run by runtests.jl. Only intended to be checked manually.
 using Plots
+
 const test_funcs = [
     (x -> 2, 0, 1),
     (x -> x, -1, 1),
@@ -24,11 +25,26 @@ const test_funcs = [
     (x -> sin(x) / x, -6, 6),
     (x -> tan(x^3 - x + 1) + 1 / (x + 3exp(x)), -2, 2),
 ]
-##
-plots = [plot(func...) for func in test_funcs]
-pitchfork = plot(x -> sqrt(x), 0, 10)
-plot!(pitchfork, x -> -sqrt(x), 0, 10)
-plot!(pitchfork, x -> 0, -10, 0)
-plot!(pitchfork, x -> 0, 0, 10, linestyle = :dash)
-push!(plots, pitchfork)
-display.(plots)
+
+main() = begin
+    plots = [plot(func...) for func in test_funcs]
+
+    pitchfork = plot(x -> sqrt(x), 0, 10)
+    plot!(pitchfork, x -> -sqrt(x), 0, 10)
+    plot!(pitchfork, x -> 0, -10, 0)
+    plot!(pitchfork, x -> 0, 0, 10, linestyle = :dash)
+    push!(plots, pitchfork)
+
+    np = length(plots)
+    m = ceil(Int, √(np)) + 1
+    n, r = divrem(np, m)
+    r == 0 || (n += 1)
+    append!(plots, [plot() for _ in 1:(m * n - np)])
+
+    @assert length(plots) == m * n
+
+    png(plot(plots...; layout = (m, n), size = (m * 600, n * 400)), "grid")
+    return
+end
+
+main()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -204,31 +204,41 @@ end
     end
 end
 
-# ----------------------
-# adapted grid
-
 @testset "adapted grid" begin
-    f = sin
-    int = (0, π)
-    xs, fs = adapted_grid(f, int)
-    l = length(xs) - 1
-    for i in 1:l
-        for λ in 0:0.1:1
-            # test that `f` is well approximated by a line
-            # in the interval `(xs[i], xs[i+1])`
-            x = λ * xs[i] + (1 - λ) * xs[i + 1]
-            y = λ * fs[i] + (1 - λ) * fs[i + 1]
-            @test y ≈ f(x) atol = 1e-2
+    let f = sin, int = (0, π)
+        xs, fs = adapted_grid(f, int)
+        l = length(xs) - 1
+        for i in 1:l
+            for λ in 0:0.1:1
+                # test that `f` is well approximated by a line
+                # in the interval `(xs[i], xs[i+1])`
+                x = λ * xs[i] + (1 - λ) * xs[i + 1]
+                y = λ * fs[i] + (1 - λ) * fs[i + 1]
+                @test y ≈ f(x) atol = 1e-2
+            end
         end
     end
 
-    int = (2, 2)
-    xs, fs = adapted_grid(f, int)
-    @test xs == [2]
-    @test fs == [f(2)]
+    let f = sin, int = (2, 2)
+        xs, fs = adapted_grid(f, int)
+        @test xs == [2]
+        @test fs == [f(2)]
+    end
 
-    int = (2, 1)
-    @test_throws ArgumentError adapted_grid(f, int)
+    let f = sin, int = (2, 1)
+        @test_throws ArgumentError adapted_grid(f, int)
+    end
+
+    p(x) = (x < 0.0 || x > 1.0 ? 0.0 : 1.0 + x)
+    let f = x -> p(2(x - 3)), int = (-5, 5)  # JuliaPlots/Plots.jl/issues/4106
+        xs, fs = adapted_grid(f, int)
+        @test count(fs .> 1.5) > 10
+    end
+
+    let f = sinc, int = (0, 40)  # JuliaPlots/Plots.jl/issues/3894
+        xs, fs = adapted_grid(f, int)
+        @test length(xs) > 400
+    end
 end
 
 @testset "zscale" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -207,8 +207,7 @@ end
 @testset "adapted grid" begin
     let f = sin, int = (0, π)
         xs, fs = adapted_grid(f, int)
-        l = length(xs) - 1
-        for i in 1:l
+        for i in 1:length(xs) - 1
             for λ in 0:0.1:1
                 # test that `f` is well approximated by a line
                 # in the interval `(xs[i], xs[i+1])`
@@ -233,6 +232,7 @@ end
     let f = x -> p(2(x - 3)), int = (-5, 5)  # JuliaPlots/Plots.jl/issues/4106
         xs, fs = adapted_grid(f, int)
         @test count(fs .> 1.5) > 10
+        @test fs |> extrema |> collect |> diff |> first > 1.9
     end
 
     let f = sinc, int = (0, 40)  # JuliaPlots/Plots.jl/issues/3894

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -207,7 +207,7 @@ end
 @testset "adapted grid" begin
     let f = sin, int = (0, π)
         xs, fs = adapted_grid(f, int)
-        for i in 1:length(xs) - 1
+        for i in 1:(length(xs) - 1)
             for λ in 0:0.1:1
                 # test that `f` is well approximated by a line
                 # in the interval `(xs[i], xs[i+1])`


### PR DESCRIPTION
Fix https://github.com/JuliaPlots/Plots.jl/issues/3894.
Fix https://github.com/JuliaPlots/Plots.jl/issues/4106.

Ideally, we should pass `curvature` and `n_points` arguments to `adapted_grid` to `RecipesPipeline.jl` see:
https://github.com/JuliaPlots/RecipesPipeline.jl/blob/00ed890cb63f5d65183f0a10f4172f5124a2f746/src/user_recipe.jl#L353,
and as parametric function arguments to `plot(...)`.
I leave this as an improvement for someone else to work on.

```julia
using Plots; gr()

p(x) = x < 0. || x > 1. ? 0. : 1. + x

main() = begin
  k, s = 2., 3.

  @time p1 = plot(x -> p(k * (x - s)))  # pr: 31 -> 85 points - master: 21 -> 21
  # pr    : 0.001934 seconds (16.64 k allocations: 435.133 KiB)
  # master: 0.001174 seconds (2.04 k allocations: 117.258 KiB)
  @time p2 = plot(sinc, xlims=(0., 40.))  # pr: 31 -> 419 points - master: 21 -> 133
  # pr    : 0.004952 seconds (88.47 k allocations: 1.934 MiB)
  # master: 0.001607 seconds (19.46 k allocations: 491.008 KiB)
  @time p3 = plot(sinc, xlims=(-40., 40.))  # pr: 31 -> 845 points - master: 21 -> 231
  # pr    : 0.009166 seconds (163.04 k allocations: 3.437 MiB)
  # master: 0.003502 seconds (54.13 k allocations: 1.200 MiB)

  png(p1, "adapt_1")
  png(p2, "adapt_2")
  png(p3, "adapt_3")

  return
end
```
![adapt_1](https://user-images.githubusercontent.com/13423344/158154618-5a3973d5-3988-4874-b714-761d586abd84.png)

![adapt_2](https://user-images.githubusercontent.com/13423344/158154657-907f89ab-5536-4182-95dc-e50de28cfc10.png)

![adapt_3](https://user-images.githubusercontent.com/13423344/158154643-414576a9-6d42-4991-9d15-48cc73b96860.png)

