### PR TITLE
fix `BigFloat` oob

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,12 @@ name: ci
 
 on:
   push:
-    branches:
-      - master
+    branches: [master]
   pull_request:
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 defaults:
   run:

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -2,10 +2,13 @@ name: format
 
 on:
   push:
-    branches:
-      - 'master'
+    branches: [master]
     tags: '*'
   pull_request:
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   check:

--- a/Project.toml
+++ b/Project.toml
@@ -20,9 +20,10 @@ Reexport = "1"
 julia = "1.6"
 
 [extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["StableRNGs", "Statistics", "Test"]
+test = ["Pkg", "StableRNGs", "Statistics", "Test"]

--- a/src/colorschemes.jl
+++ b/src/colorschemes.jl
@@ -25,7 +25,7 @@ abstract type ColorGradient <: AbstractColorList end
 Base.getindex(cg::ColorGradient, x::Union{AbstractFloat,AbstractVector{<:AbstractFloat}}) =
     get(cg, x)
 function Base.get(cg::ColorGradient, v::AbstractArray, rangescale = (0.0, 1.0))
-    rangescale == :extrema && (rangescale = extrema(v))
+    rangescale === :extrema && (rangescale = extrema(v))
     map(x -> get(cg, x, rangescale), v)
 end
 
@@ -193,9 +193,9 @@ function cgrad(
     rev && (colors = reverse(colors))
     values = if scale in (:log, :log10) || scale isa typeof(log10)
         log10.(ColorSchemes.remap(values, 0, 1, 1, 10))
-    elseif scale == :log2 || scale isa typeof(log2)
+    elseif scale === :log2 || scale isa typeof(log2)
         log2.(ColorSchemes.remap(values, 0, 1, 1, 2))
-    elseif scale == :ln || scale isa typeof(log)
+    elseif scale === :ln || scale isa typeof(log)
         log.(ColorSchemes.remap(values, 0, 1, 1, ℯ))
     elseif scale in (:exp, :exp10) || scale isa typeof(exp10) || scale isa typeof(exp)
         ColorSchemes.remap(exp10.(values), 1, 10, 0, 1)
@@ -233,8 +233,8 @@ cgrad(; kw...) = cgrad(DEFAULT_COLOR_GRADIENT[]; kw...)
 default_cgrad(cg; kw...) = DEFAULT_COLOR_GRADIENT[] = cgrad(cg; kw...)
 
 function get_rangescale(rangescale)
-    rangescale == :clamp && return (0.0, 1.0)
-    rangescale == :extrema && return extrema(x)
+    rangescale === :clamp && return (0.0, 1.0)
+    rangescale === :extrema && return extrema(x)
     (rangescale isa NTuple{2,Number}) || error(
         "rangescale ($rangescale) not supported, should be :clamp, :extrema or tuple (minVal, maxVal).  Got $(rangescale).",
     )

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -383,7 +383,9 @@ function optimize_ticks(
     end
 
     if year(x_max) - year(x_min) <= 1 && scale !== :year
-        if year(x_max) == year(x_min) && month(x_max) - month(x_min) <= 1 && scale !== :month
+        if year(x_max) == year(x_min) &&
+           month(x_max) - month(x_min) <= 1 &&
+           scale !== :month
             ticks = DateTime[]
 
             scales = [

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -382,8 +382,8 @@ function optimize_ticks(
         x_max += Second(1)
     end
 
-    if year(x_max) - year(x_min) <= 1 && scale != :year
-        if year(x_max) == year(x_min) && month(x_max) - month(x_min) <= 1 && scale != :month
+    if year(x_max) - year(x_min) <= 1 && scale !== :year
+        if year(x_max) == year(x_min) && month(x_max) - month(x_min) <= 1 && scale !== :month
             ticks = DateTime[]
 
             scales = [
@@ -397,7 +397,7 @@ function optimize_ticks(
             ]
 
             # ticks on week boundries
-            if x_min + Day(7) < x_max || scale == :week
+            if x_min + Day(7) < x_max || scale === :week
                 push!(ticks, x_min)
                 while true
                     next_month = Date(year(ticks[end]), month(ticks[end])) + Month(1)
@@ -411,7 +411,7 @@ function optimize_ticks(
                 end
             else
                 scale = nothing
-                if scale != :auto
+                if scale !== :auto
                     # TODO: manually setting scale with :day, :minute, etc
                 end
 
@@ -538,9 +538,9 @@ function multilevel_ticks(
     span = convert(Float64, Dates.toms(viewmax - viewmin))
     ticks = Dict()
     for scale in scales
-        s = if scale == :year
+        s = if scale === :year
             span / Dates.toms(Day(360))
-        elseif scale == :month
+        elseif scale === :month
             span / Dates.toms(Day(90))
         else
             span / Dates.toms(Day(1))

--- a/test/adaptive_test_functions.jl
+++ b/test/adaptive_test_functions.jl
@@ -1,4 +1,3 @@
-# This is not run by runtests.jl. Only intended to be checked manually.
 using Plots
 
 const test_funcs = [

--- a/test/downstream.jl
+++ b/test/downstream.jl
@@ -1,0 +1,49 @@
+using Pkg, PlotUtils
+
+LibGit2 = Pkg.GitTools.LibGit2
+TOML = Pkg.TOML
+
+Plots_jl = joinpath(mkpath(tempname()), "Plots.jl")
+Plots_toml = joinpath(Plots_jl, "Project.toml")
+
+# clone and checkout the latest stable version of Plots
+depot = joinpath(first(DEPOT_PATH), "registries", "General", "P", "Plots", "Versions.toml")
+stable = maximum(VersionNumber.(keys(TOML.parse(read(depot, String)))))
+for i ∈ 1:6
+    try
+        global repo = Pkg.GitTools.ensure_clone(stdout, Plots_jl, "https://github.com/JuliaPlots/Plots.jl")
+        break
+    catch err
+        @warn err
+        sleep(20i)
+    end
+end
+@assert isfile(Plots_toml) "spurious network error: clone failed, bailing out"
+tag = LibGit2.GitObject(repo, "v$stable")
+hash = string(LibGit2.target(tag))
+LibGit2.checkout!(repo, hash)
+
+# fake the supported PlotUtils version for testing (for `Pkg.develop`)
+plotutils_version = Pkg.Types.read_package(normpath(@__DIR__, "..", "Project.toml")).version
+toml = TOML.parse(read(Plots_toml, String))
+toml["compat"]["PlotUtils"] = plotutils_version
+open(Plots_toml, "w") do io
+  TOML.print(io, toml)
+end
+Pkg.develop(path=Plots_jl)
+Pkg.status(["PlotUtils", "Plots"])
+
+# test basic plots creation and bitmap or vector exports
+using Plots, Test
+
+prefix = tempname()
+@time for i ∈ 1:length(Plots._examples)
+  i ∈ Plots._backend_skips[:gr] && continue  # skip unsupported examples
+  Plots._examples[i].imports ≡ nothing || continue  # skip examples requiring optional test deps
+  pl = Plots.test_examples(:gr, i; disp = false)
+  for ext in (".png", ".pdf")  # TODO: maybe more ?
+    fn = string(prefix, i, ext)
+    Plots.savefig(pl, fn)
+    @test filesize(fn) > 1_000
+  end
+end

--- a/test/downstream.jl
+++ b/test/downstream.jl
@@ -9,9 +9,13 @@ Plots_toml = joinpath(Plots_jl, "Project.toml")
 # clone and checkout the latest stable version of Plots
 depot = joinpath(first(DEPOT_PATH), "registries", "General", "P", "Plots", "Versions.toml")
 stable = maximum(VersionNumber.(keys(TOML.parse(read(depot, String)))))
-for i ∈ 1:6
+for i in 1:6
     try
-        global repo = Pkg.GitTools.ensure_clone(stdout, Plots_jl, "https://github.com/JuliaPlots/Plots.jl")
+        global repo = Pkg.GitTools.ensure_clone(
+            stdout,
+            Plots_jl,
+            "https://github.com/JuliaPlots/Plots.jl",
+        )
         break
     catch err
         @warn err
@@ -28,16 +32,16 @@ plotutils_version = Pkg.Types.read_package(normpath(@__DIR__, "..", "Project.tom
 toml = TOML.parse(read(Plots_toml, String))
 toml["compat"]["PlotUtils"] = string(plotutils_version)
 open(Plots_toml, "w") do io
-  TOML.print(io, toml)
+    TOML.print(io, toml)
 end
-Pkg.develop(path=Plots_jl)
+Pkg.develop(path = Plots_jl)
 Pkg.status(["PlotUtils", "Plots"])
 
 # test basic plots creation & display
 using Plots, Test
 
-@time for i ∈ 1:length(Plots._examples)
-  i ∈ Plots._backend_skips[:gr] && continue  # skip unsupported examples
-  Plots._examples[i].imports ≡ nothing || continue  # skip examples requiring optional test deps
-  show(devnull, Plots.test_examples(:gr, i; disp = false))  # trigger display logic
+@time for i in 1:length(Plots._examples)
+    i ∈ Plots._backend_skips[:gr] && continue  # skip unsupported examples
+    Plots._examples[i].imports ≡ nothing || continue  # skip examples requiring optional test deps
+    show(devnull, Plots.test_examples(:gr, i; disp = false))  # trigger display logic
 end

--- a/test/downstream.jl
+++ b/test/downstream.jl
@@ -26,24 +26,18 @@ LibGit2.checkout!(repo, hash)
 # fake the supported PlotUtils version for testing (for `Pkg.develop`)
 plotutils_version = Pkg.Types.read_package(normpath(@__DIR__, "..", "Project.toml")).version
 toml = TOML.parse(read(Plots_toml, String))
-toml["compat"]["PlotUtils"] = plotutils_version
+toml["compat"]["PlotUtils"] = string(plotutils_version)
 open(Plots_toml, "w") do io
   TOML.print(io, toml)
 end
 Pkg.develop(path=Plots_jl)
 Pkg.status(["PlotUtils", "Plots"])
 
-# test basic plots creation and bitmap or vector exports
+# test basic plots creation & display
 using Plots, Test
 
-prefix = tempname()
 @time for i ∈ 1:length(Plots._examples)
   i ∈ Plots._backend_skips[:gr] && continue  # skip unsupported examples
   Plots._examples[i].imports ≡ nothing || continue  # skip examples requiring optional test deps
-  pl = Plots.test_examples(:gr, i; disp = false)
-  for ext in (".png", ".pdf")  # TODO: maybe more ?
-    fn = string(prefix, i, ext)
-    Plots.savefig(pl, fn)
-    @test filesize(fn) > 1_000
-  end
+  show(devnull, Plots.test_examples(:gr, i; disp = false))  # trigger display logic
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -270,3 +270,5 @@ end
     @test stats.bytes < 1_000  # ~ 736 (on 1.8)
     @test stats.time < 1e-3  # ~ 0.56ms (on 1.8)
 end
+
+include("downstream.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,9 @@ const C0 = RGBA{PlotUtils.Colors.N0f8}
     @test typeof(grad) == PlotUtils.ContinuousColorGradient
     @test plot_color(grad) === grad
 
+    # JuliaPlots/Plots.jl/issues/4270
+    @test get(grad, BigFloat(1), (-0.00033546262790251185, 1.0)) isa RGBA{BigFloat}
+
     grad = cgrad([:red, "blue"])
     @test color_list(grad) == C[colorant"red", colorant"blue"]
     @test grad.values == collect(range(0, stop = 1, length = 2))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -275,3 +275,8 @@ end
     include("downstream.jl")
     @test true
 end
+
+@testset "adaptive" begin
+    include("adaptive_test_functions.jl")
+    @test true
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -276,14 +276,14 @@ end
 
 if Sys.islinux()
     @testset "downstream" begin
-        withenv("GKSwstype" => "nul")
+        withenv("GKSwstype" => "nul") do
             include("downstream.jl")
         end
         @test true
     end
 
     @testset "adaptive" begin
-        withenv("GKSwstype" => "nul")
+        withenv("GKSwstype" => "nul") do
             include("adaptive_test_functions.jl")
         end
         @test true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -271,4 +271,7 @@ end
     @test stats.time < 1e-3  # ~ 0.56ms (on 1.8)
 end
 
-include("downstream.jl")
+@testset "downstream" begin
+    include("downstream.jl")
+    @test true
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -271,12 +271,14 @@ end
     @test stats.time < 1e-3  # ~ 0.56ms (on 1.8)
 end
 
-@testset "downstream" begin
-    include("downstream.jl")
-    @test true
-end
+if Sys.islinux()
+    @testset "downstream" begin
+        include("downstream.jl")
+        @test true
+    end
 
-@testset "adaptive" begin
-    include("adaptive_test_functions.jl")
-    @test true
+    @testset "adaptive" begin
+        include("adaptive_test_functions.jl")
+        @test true
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -273,12 +273,16 @@ end
 
 if Sys.islinux()
     @testset "downstream" begin
-        include("downstream.jl")
+        withenv("GKSwstype" => "nul")
+            include("downstream.jl")
+        end
         @test true
     end
 
     @testset "adaptive" begin
-        include("adaptive_test_functions.jl")
+        withenv("GKSwstype" => "nul")
+            include("adaptive_test_functions.jl")
+        end
         @test true
     end
 end


### PR DESCRIPTION
Fix https://discourse.julialang.org/t/display-function-returning-boundserror/93548.

Fix https://github.com/JuliaPlots/Plots.jl/issues/4270.

Reproducer:
```julia
julia> using PlotUtils
julia> get(cgrad(), BigFloat(1), (-0.00033546262790251185, 1.0)) isa RGBA{BigFloat}
ERROR: BoundsError: attempt to access 256-element Vector{Float64} at index [257]
Stacktrace:
 [1] getindex
   @ ./array.jl:924 [inlined]
 [2] get(cg::PlotUtils.ContinuousColorGradient, x::BigFloat, rangescale::Tuple{Float64, Float64})
   @ PlotUtils [...]/PlotUtils/M092a/src/colorschemes.jl:68
 [3] top-level scope
   @ REPL[2]:1
```

- we don't need to handle the color sampling in `PlotUtils` since it is already implemented in `ColorSchemes`;
- add downstream `Plots` tests;
- bump coverage.

Test `Plots`, `Makie` and `CairoMakie` pass locally.
