### PR TITLE
Make tick finding more compatible with Float64

### DIFF
--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -154,7 +154,9 @@ function optimize_ticks(
     span_buffer = nothing,
     scale = nothing,
 ) where {T}
-    if isapprox(x_min, x_max, rtol = 1000.0 * eps(T))
+
+    rtol = T isa AbstractFloat ? 1000.0 * eps(T) : Base.rtoldefault(x_min, x_max, 0)
+    if isapprox(x_min, x_max, rtol = rtol)
         return fallback_ticks(x_min, x_max, k_min, k_max, strict_span)
     end
 

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -154,7 +154,9 @@ function optimize_ticks(
     span_buffer = nothing,
     scale = nothing,
 ) where {T}
-    x_min ≈ x_max && return fallback_ticks(x_min, x_max, k_min, k_max, strict_span)
+    if isapprox(x_min, x_max, rtol = 1000.0 * eps(T))
+        return fallback_ticks(x_min, x_max, k_min, k_max, strict_span)
+    end
 
     F = float(T)
     Qv = F[q[1] for q ∈ Q]

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -154,7 +154,6 @@ function optimize_ticks(
     span_buffer = nothing,
     scale = nothing,
 ) where {T}
-
     rtol = T <: AbstractFloat ? 1000.0 * eps(T) : Base.rtoldefault(x_min, x_max, 0)
     if isapprox(x_min, x_max, rtol = rtol)
         return fallback_ticks(x_min, x_max, k_min, k_max, strict_span)

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -155,7 +155,7 @@ function optimize_ticks(
     scale = nothing,
 ) where {T}
 
-    rtol = T isa AbstractFloat ? 1000.0 * eps(T) : Base.rtoldefault(x_min, x_max, 0)
+    rtol = T <: AbstractFloat ? 1000.0 * eps(T) : Base.rtoldefault(x_min, x_max, 0)
     if isapprox(x_min, x_max, rtol = rtol)
         return fallback_ticks(x_min, x_max, k_min, k_max, strict_span)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -119,6 +119,10 @@ end
 @testset "ticks" begin
     @test optimize_ticks(-1, 2) == ([-1.0, 0.0, 1.0, 2.0], -1.0, 2.0)
 
+    # check if ticks still generate if max - min << abs(min) (i.e. for Float64 ranges)
+    @test optimize_ticks(1e11 - 1, 1e11 + 2) == (1e11 .+ (-1:2), 1e11 - 1.0, 1e11 + 2.0)
+
+
     @testset "dates" begin
         dt1, dt2 = Dates.value(DateTime(2000)), Dates.value(DateTime(2100))
         @test optimize_datetime_ticks(dt1, dt2) == (

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,7 +122,6 @@ end
     # check if ticks still generate if max - min << abs(min) (i.e. for Float64 ranges)
     @test optimize_ticks(1e11 - 1, 1e11 + 2) == (1e11 .+ (-1:2), 1e11 - 1.0, 1e11 + 2.0)
 
-
     @testset "dates" begin
         dt1, dt2 = Dates.value(DateTime(2000)), Dates.value(DateTime(2100))
         @test optimize_datetime_ticks(dt1, dt2) == (


### PR DESCRIPTION
While working on https://github.com/MakieOrg/Makie.jl/pull/3663 I noticed that ticks are broken for `1e9 .+ (1:10)`:

![Screenshot from 2024-03-04 15-25-37](https://github.com/JuliaPlots/PlotUtils.jl/assets/10947937/1ef44ec6-ff1a-440e-bac3-1c152e216868)

In this case PlotUtils switches to `fallback_ticks` as `9 / 1e9 < sqrt(eps(Float64)) ~ 1e-8` and we get `(min, 0.5 * (max + min), max)`. Our pretty-string functions then round those values to integers, I assume.

To avoid the PlotUtils part of the problem I think just adjusting the rtol is enough. With `rtol = 1000.0 * eps(T)` the tolerance should be about the same for Float32 and 1e-13 for Float64. With that the plot becomes:

![Screenshot from 2024-03-04 17-37-37](https://github.com/JuliaPlots/PlotUtils.jl/assets/10947937/a23f661c-8ef6-4bca-9db2-10e2fda000b5)
