### PR TITLE
change default colors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PlotUtils"
 uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
-version = "1.4.1"
+version = "2.0.0"
 
 [deps]
 ColorSchemes = "35d6a980-a343-548e-a6ea-1d62b119f2f4"

--- a/src/PlotUtils.jl
+++ b/src/PlotUtils.jl
@@ -36,7 +36,7 @@ export optimize_ticks, optimize_datetime_ticks
 
 include("ticks.jl")
 
-const _default_colorscheme = generate_colorscheme()
+const _default_colorscheme = ColorSchemes.colorscheme(:seaborn_colorblind)
 
 if VERSION ≥ v"1.8.0"
     @compile_workload begin

--- a/src/colorschemes.jl
+++ b/src/colorschemes.jl
@@ -237,7 +237,7 @@ function cgrad(
 end
 
 function cgrad(colors, args...; kwargs...)
-    colors ≡ :default && (colors = :inferno)
+    colors ≡ :default && (colors = DEFAULT_COLOR_GRADIENT[])
     cgrad(get_colorscheme(colors), args...; kwargs...)
 end
 
@@ -335,7 +335,7 @@ is_colorscheme(sym) =
     sym ∈ keys(COLORSCHEME_ALIASES) ||
     sym ∈ keys(MISC_COLORSCHEMES)
 
-const DEFAULT_COLOR_GRADIENT = Ref(cgrad(ColorSchemes.colorschemes[:inferno]))
+const DEFAULT_COLOR_GRADIENT = Ref(cgrad(ColorSchemes.colorschemes[:haline]))
 
 ## Compat
 
@@ -422,6 +422,7 @@ const TEST_COLORS = RGBA{Float64}[
 ]
 
 const MISC_COLORSCHEMES = Dict{Symbol,ColorScheme}(
+    :default => generate_colorscheme(),
     :blues => ColorScheme(RGBA{Float64}[colorant"lightblue", colorant"darkblue"]),
     :reds => ColorScheme(RGBA{Float64}[colorant"lightpink", colorant"darkred"]),
     :greens => ColorScheme(RGBA{Float64}[colorant"lightgreen", colorant"darkgreen"]),


### PR DESCRIPTION
What I got from [the poll](https://discourse.julialang.org/t/new-colorscheme-for-plots-jl-2-0/117841) is that people like mostly like the blue/green-ish color gradients as default and seaborn colorblind also had a majority.

I don't really like how it looks like every other plotting library, but I also don't mind too much.

Closes  https://github.com/JuliaPlots/Plots.jl/issues/4966

xref: https://github.com/JuliaPlots/Plots.jl/issues/4565